### PR TITLE
Add PHP todo app with authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+database.sqlite

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # otodo
-the online todo list app
+
+A simple PHP online todo list application with user authentication and SQLite storage. The interface uses [Bootstrap](https://getbootstrap.com/) for a mobile‑responsive layout.
+
+## Features
+
+- User registration and login
+- Add, complete, and delete tasks
+- Tasks stored per user in an SQLite database
+- Responsive design for desktop and mobile browsers
+
+## Getting Started
+
+1. Ensure PHP 8+ with SQLite support is installed.
+2. Start the built-in web server:
+   ```bash
+   php -S localhost:8000
+   ```
+3. Open <http://localhost:8000/login.php> in your browser to register and start using the app.
+
+The application will create `database.sqlite` in the project directory on first run.

--- a/add_task.php
+++ b/add_task.php
@@ -1,0 +1,16 @@
+<?php
+require_once 'db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$description = trim($_POST['description'] ?? '');
+if ($description !== '') {
+    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description) VALUES (:uid, :description)');
+    $stmt->execute([':uid' => $_SESSION['user_id'], ':description' => $description]);
+}
+
+header('Location: index.php');
+exit();

--- a/db.php
+++ b/db.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+
+function get_db() {
+    static $db = null;
+    if ($db === null) {
+        $db = new PDO('sqlite:' . __DIR__ . '/database.sqlite');
+        $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $db->exec("CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL
+        )");
+
+        $db->exec("CREATE TABLE IF NOT EXISTS tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            done INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY(user_id) REFERENCES users(id)
+        )");
+    }
+    return $db;
+}

--- a/delete_task.php
+++ b/delete_task.php
@@ -1,0 +1,16 @@
+<?php
+require_once 'db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$id = (int)($_GET['id'] ?? 0);
+if ($id) {
+    $stmt = get_db()->prepare('DELETE FROM tasks WHERE id = :id AND user_id = :uid');
+    $stmt->execute([':id' => $id, ':uid' => $_SESSION['user_id']]);
+}
+
+header('Location: index.php');
+exit();

--- a/index.php
+++ b/index.php
@@ -1,0 +1,54 @@
+<?php
+require_once 'db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$db = get_db();
+$stmt = $db->prepare('SELECT id, description, done FROM tasks WHERE user_id = :uid ORDER BY id DESC');
+$stmt->execute([':uid' => $_SESSION['user_id']]);
+$tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Todo List</title>
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-light bg-white mb-4">
+    <div class="container">
+        <span class="navbar-brand mb-0 h1">Todo App</span>
+        <div class="d-flex align-items-center">
+            <span class="me-3">Hello, <?=htmlspecialchars($_SESSION['username'])?></span>
+            <a href="logout.php" class="btn btn-outline-secondary btn-sm">Logout</a>
+        </div>
+    </div>
+</nav>
+<div class="container">
+    <form action="add_task.php" method="post" class="d-flex mb-3">
+        <input type="text" name="description" class="form-control me-2" placeholder="New task" required>
+        <button class="btn btn-primary" type="submit">Add</button>
+    </form>
+    <ul class="list-group">
+        <?php foreach ($tasks as $task): ?>
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>">
+                    <?=htmlspecialchars($task['description'])?>
+                </span>
+                <span>
+                    <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-success me-1">
+                        <?=$task['done'] ? 'Undo' : 'Done'?>
+                    </a>
+                    <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-danger">Delete</a>
+                </span>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+</div>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,58 @@
+<?php
+require_once 'db.php';
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit();
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    if ($username === '' || $password === '') {
+        $error = 'Please fill in all fields';
+    } else {
+        $stmt = get_db()->prepare('SELECT id, password FROM users WHERE username = :username');
+        $stmt->execute([':username' => $username]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($user && password_verify($password, $user['password'])) {
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['username'] = $username;
+            header('Location: index.php');
+            exit();
+        } else {
+            $error = 'Invalid credentials';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Login</title>
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <h2 class="mb-4">Login</h2>
+    <?php if ($error): ?>
+        <div class="alert alert-danger"><?=$error?></div>
+    <?php endif; ?>
+    <form method="post" class="mb-3">
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+    <p>Don't have an account? <a href="register.php">Register</a></p>
+</div>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+require_once 'db.php';
+
+session_unset();
+session_destroy();
+header('Location: login.php');
+exit();

--- a/register.php
+++ b/register.php
@@ -1,0 +1,56 @@
+<?php
+require_once 'db.php';
+
+if (isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit();
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    if ($username === '' || $password === '') {
+        $error = 'Please fill in all fields';
+    } else {
+        try {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = get_db()->prepare('INSERT INTO users (username, password) VALUES (:username, :password)');
+            $stmt->execute([':username' => $username, ':password' => $hash]);
+            header('Location: login.php');
+            exit();
+        } catch (PDOException $e) {
+            $error = 'Username already taken';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Register</title>
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <h2 class="mb-4">Register</h2>
+    <?php if ($error): ?>
+        <div class="alert alert-danger"><?=$error?></div>
+    <?php endif; ?>
+    <form method="post" class="mb-3">
+        <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Register</button>
+    </form>
+    <p>Already have an account? <a href="login.php">Login</a></p>
+</div>
+</body>
+</html>

--- a/toggle_task.php
+++ b/toggle_task.php
@@ -1,0 +1,17 @@
+<?php
+require_once 'db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$id = (int)($_GET['id'] ?? 0);
+if ($id) {
+    $db = get_db();
+    $stmt = $db->prepare('UPDATE tasks SET done = 1 - done WHERE id = :id AND user_id = :uid');
+    $stmt->execute([':id' => $id, ':uid' => $_SESSION['user_id']]);
+}
+
+header('Location: index.php');
+exit();


### PR DESCRIPTION
## Summary
- Implement SQLite-backed todo application with user registration and login.
- Add responsive task list interface using Bootstrap with add, complete, and delete actions.
- Document setup and usage in README; ignore database file.

## Testing
- `php -l *.php`

------
https://chatgpt.com/codex/tasks/task_e_68973b5a950483268dc7baf7cc3546fd