### PR TITLE
Add due date and description fields to tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A simple PHP online todo list application with user authentication and SQLite st
 - Add, complete, and delete tasks
 - Tasks stored per user in an SQLite database
 - Responsive design for desktop and mobile browsers
+- Optional due dates and descriptions for tasks
 
 ## Getting Started
 

--- a/add_task.php
+++ b/add_task.php
@@ -7,9 +7,16 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $description = trim($_POST['description'] ?? '');
+$due_date = trim($_POST['due_date'] ?? '');
+$details = trim($_POST['details'] ?? '');
 if ($description !== '') {
-    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description) VALUES (:uid, :description)');
-    $stmt->execute([':uid' => $_SESSION['user_id'], ':description' => $description]);
+    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description, due_date, details) VALUES (:uid, :description, :due_date, :details)');
+    $stmt->execute([
+        ':uid' => $_SESSION['user_id'],
+        ':description' => $description,
+        ':due_date' => $due_date !== '' ? $due_date : null,
+        ':details' => $details !== '' ? $details : null,
+    ]);
 }
 
 header('Location: index.php');

--- a/db.php
+++ b/db.php
@@ -17,9 +17,20 @@ function get_db() {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL,
             description TEXT NOT NULL,
+            due_date TEXT,
+            details TEXT,
             done INTEGER NOT NULL DEFAULT 0,
             FOREIGN KEY(user_id) REFERENCES users(id)
         )");
+
+        // Ensure new columns exist for older databases
+        $columns = $db->query('PRAGMA table_info(tasks)')->fetchAll(PDO::FETCH_COLUMN, 1);
+        if (!in_array('due_date', $columns, true)) {
+            $db->exec('ALTER TABLE tasks ADD COLUMN due_date TEXT');
+        }
+        if (!in_array('details', $columns, true)) {
+            $db->exec('ALTER TABLE tasks ADD COLUMN details TEXT');
+        }
     }
     return $db;
 }

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $db = get_db();
-$stmt = $db->prepare('SELECT id, description, done FROM tasks WHERE user_id = :uid ORDER BY id DESC');
+$stmt = $db->prepare('SELECT id, description, due_date, details, done FROM tasks WHERE user_id = :uid ORDER BY id DESC');
 $stmt->execute([':uid' => $_SESSION['user_id']]);
 $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -30,22 +30,38 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
     </div>
 </nav>
 <div class="container">
-    <form action="add_task.php" method="post" class="d-flex mb-3">
-        <input type="text" name="description" class="form-control me-2" placeholder="New task" required>
+    <form action="add_task.php" method="post" class="mb-3">
+        <div class="mb-2">
+            <input type="text" name="description" class="form-control" placeholder="New task" required>
+        </div>
+        <div class="mb-2">
+            <input type="date" name="due_date" class="form-control" placeholder="Due date">
+        </div>
+        <div class="mb-2">
+            <textarea name="details" class="form-control" placeholder="Description"></textarea>
+        </div>
         <button class="btn btn-primary" type="submit">Add</button>
     </form>
     <ul class="list-group">
         <?php foreach ($tasks as $task): ?>
-            <li class="list-group-item d-flex justify-content-between align-items-center">
-                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>">
-                    <?=htmlspecialchars($task['description'])?>
-                </span>
-                <span>
-                    <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-success me-1">
-                        <?=$task['done'] ? 'Undo' : 'Done'?>
-                    </a>
-                    <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-danger">Delete</a>
-                </span>
+            <li class="list-group-item">
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'])?></span>
+                        <?php if (!empty($task['due_date'])): ?>
+                            <div class="small text-muted">Due: <?=htmlspecialchars($task['due_date'])?></div>
+                        <?php endif; ?>
+                        <?php if (!empty($task['details'])): ?>
+                            <div class="small"><?=nl2br(htmlspecialchars($task['details']))?></div>
+                        <?php endif; ?>
+                    </div>
+                    <span>
+                        <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-success me-1">
+                            <?=$task['done'] ? 'Undo' : 'Done'?>
+                        </a>
+                        <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-danger">Delete</a>
+                    </span>
+                </div>
             </li>
         <?php endforeach; ?>
     </ul>


### PR DESCRIPTION
## Summary
- allow tasks to store optional due dates and detailed descriptions
- extend UI to capture and display the new fields
- document support for richer task metadata

## Testing
- `php -l db.php`
- `php -l add_task.php`
- `php -l index.php`
- `php -l delete_task.php toggle_task.php login.php logout.php register.php`

------
https://chatgpt.com/codex/tasks/task_e_68973e582b8883268a64c74c51b88e9c