### PR TITLE
Streamline task creation and add detail editing page

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -7,15 +7,11 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $description = trim($_POST['description'] ?? '');
-$due_date = trim($_POST['due_date'] ?? '');
-$details = trim($_POST['details'] ?? '');
 if ($description !== '') {
-    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description, due_date, details) VALUES (:uid, :description, :due_date, :details)');
+    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description) VALUES (:uid, :description)');
     $stmt->execute([
         ':uid' => $_SESSION['user_id'],
         ':description' => $description,
-        ':due_date' => $due_date !== '' ? $due_date : null,
-        ':details' => $details !== '' ? $details : null,
     ]);
 }
 

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $db = get_db();
-$stmt = $db->prepare('SELECT id, description, due_date, details, done FROM tasks WHERE user_id = :uid ORDER BY id DESC');
+$stmt = $db->prepare('SELECT id, description, due_date, done FROM tasks WHERE user_id = :uid ORDER BY id DESC');
 $stmt->execute([':uid' => $_SESSION['user_id']]);
 $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -31,40 +31,17 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 </nav>
 <div class="container">
     <form action="add_task.php" method="post" class="mb-3">
-        <div class="mb-2">
-            <input type="text" name="description" class="form-control" placeholder="New task" required>
-        </div>
-        <div class="mb-2">
-            <input type="date" name="due_date" class="form-control" placeholder="Due date">
-        </div>
-        <div class="mb-2">
-            <textarea name="details" class="form-control" placeholder="Description"></textarea>
-        </div>
-        <button class="btn btn-primary" type="submit">Add</button>
+        <input type="text" name="description" class="form-control" placeholder="New task" required>
+        <button type="submit" class="d-none"></button>
     </form>
-    <ul class="list-group">
+    <div class="list-group">
         <?php foreach ($tasks as $task): ?>
-            <li class="list-group-item">
-                <div class="d-flex justify-content-between align-items-start">
-                    <div>
-                        <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'])?></span>
-                        <?php if (!empty($task['due_date'])): ?>
-                            <div class="small text-muted">Due: <?=htmlspecialchars($task['due_date'])?></div>
-                        <?php endif; ?>
-                        <?php if (!empty($task['details'])): ?>
-                            <div class="small"><?=nl2br(htmlspecialchars($task['details']))?></div>
-                        <?php endif; ?>
-                    </div>
-                    <span>
-                        <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-success me-1">
-                            <?=$task['done'] ? 'Undo' : 'Done'?>
-                        </a>
-                        <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-sm btn-danger">Delete</a>
-                    </span>
-                </div>
-            </li>
+            <a href="task.php?id=<?=$task['id']?>" class="list-group-item list-group-item-action d-flex justify-content-between">
+                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'])?></span>
+                <span class="text-muted"><?=htmlspecialchars($task['due_date'])?></span>
+            </a>
         <?php endforeach; ?>
-    </ul>
+    </div>
 </div>
 </body>
 </html>

--- a/task.php
+++ b/task.php
@@ -1,0 +1,69 @@
+<?php
+require_once 'db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit();
+}
+
+$db = get_db();
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$stmt = $db->prepare('SELECT id, description, due_date, details, done FROM tasks WHERE id = :id AND user_id = :uid');
+$stmt->execute([':id' => $id, ':uid' => $_SESSION['user_id']]);
+$task = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$task) {
+    header('Location: index.php');
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $description = trim($_POST['description'] ?? '');
+    $due_date = trim($_POST['due_date'] ?? '');
+    $details = trim($_POST['details'] ?? '');
+    $stmt = $db->prepare('UPDATE tasks SET description = :description, due_date = :due_date, details = :details WHERE id = :id AND user_id = :uid');
+    $stmt->execute([
+        ':description' => $description,
+        ':due_date' => $due_date !== '' ? $due_date : null,
+        ':details' => $details !== '' ? $details : null,
+        ':id' => $id,
+        ':uid' => $_SESSION['user_id'],
+    ]);
+    header('Location: index.php');
+    exit();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Task Details</title>
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-light bg-white mb-4">
+    <div class="container">
+        <a href="index.php" class="navbar-brand">Todo App</a>
+    </div>
+</nav>
+<div class="container">
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">Title</label>
+            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars($task['description'])?>" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Due Date</label>
+            <input type="date" name="due_date" class="form-control" value="<?=htmlspecialchars($task['due_date'])?>">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea name="details" class="form-control" rows="4"><?=htmlspecialchars($task['details'])?></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-success ms-2"><?=$task['done'] ? 'Undo' : 'Done'?></a>
+        <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-danger ms-2">Delete</a>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Simplify new task creation to a single text field submitted on enter
- List tasks with title left-aligned and due date right-aligned, linking to detail page
- Add task detail page for editing title, due date, and description with larger textarea

## Testing
- `php -l index.php`
- `php -l add_task.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6897424e5cb483268f7c27215beaab39