### PR TITLE
Add task priorities with ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A simple PHP online todo list application with user authentication and SQLite st
 - Tasks stored per user in an SQLite database
 - Responsive design for desktop and mobile browsers
 - Optional due dates and descriptions for tasks
+- Task priorities with color-coded badges
 
 ## Getting Started
 

--- a/add_task.php
+++ b/add_task.php
@@ -9,13 +9,18 @@ if (!isset($_SESSION['user_id'])) {
 $description = trim($_POST['description'] ?? '');
 $due_date = trim($_POST['due_date'] ?? '');
 $details = trim($_POST['details'] ?? '');
+$priority = (int)($_POST['priority'] ?? 2);
+if ($priority < 1 || $priority > 3) {
+    $priority = 2;
+}
 if ($description !== '') {
-    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description, due_date, details) VALUES (:uid, :description, :due_date, :details)');
+    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description, due_date, details, priority) VALUES (:uid, :description, :due_date, :details, :priority)');
     $stmt->execute([
         ':uid' => $_SESSION['user_id'],
         ':description' => $description,
         ':due_date' => $due_date !== '' ? $due_date : null,
         ':details' => $details !== '' ? $details : null,
+        ':priority' => $priority,
     ]);
 }
 

--- a/db.php
+++ b/db.php
@@ -19,6 +19,7 @@ function get_db() {
             description TEXT NOT NULL,
             due_date TEXT,
             details TEXT,
+            priority INTEGER NOT NULL DEFAULT 2,
             done INTEGER NOT NULL DEFAULT 0,
             FOREIGN KEY(user_id) REFERENCES users(id)
         )");
@@ -30,6 +31,9 @@ function get_db() {
         }
         if (!in_array('details', $columns, true)) {
             $db->exec('ALTER TABLE tasks ADD COLUMN details TEXT');
+        }
+        if (!in_array('priority', $columns, true)) {
+            $db->exec('ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 2');
         }
     }
     return $db;

--- a/index.php
+++ b/index.php
@@ -7,9 +7,11 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $db = get_db();
-$stmt = $db->prepare('SELECT id, description, due_date, details, done FROM tasks WHERE user_id = :uid ORDER BY id DESC');
+$stmt = $db->prepare('SELECT id, description, due_date, details, done, priority FROM tasks WHERE user_id = :uid ORDER BY due_date IS NULL, due_date, priority DESC, id DESC');
 $stmt->execute([':uid' => $_SESSION['user_id']]);
 $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$priority_labels = [1 => 'Low', 2 => 'Medium', 3 => 'High'];
+$priority_classes = [1 => 'bg-success', 2 => 'bg-warning', 3 => 'bg-danger'];
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -38,6 +40,13 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <input type="date" name="due_date" class="form-control" placeholder="Due date">
         </div>
         <div class="mb-2">
+            <select name="priority" class="form-select">
+                <option value="3">High</option>
+                <option value="2" selected>Medium</option>
+                <option value="1">Low</option>
+            </select>
+        </div>
+        <div class="mb-2">
             <textarea name="details" class="form-control" placeholder="Description"></textarea>
         </div>
         <button class="btn btn-primary" type="submit">Add</button>
@@ -47,6 +56,9 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <li class="list-group-item">
                 <div class="d-flex justify-content-between align-items-start">
                     <div>
+                        <span class="badge <?= $priority_classes[$task['priority']] ?? 'bg-secondary' ?> me-1">
+                            <?= $priority_labels[$task['priority']] ?? '' ?>
+                        </span>
                         <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'])?></span>
                         <?php if (!empty($task['due_date'])): ?>
                             <div class="small text-muted">Due: <?=htmlspecialchars($task['due_date'])?></div>


### PR DESCRIPTION
## Summary
- add priority column to tasks and migrate existing databases
- allow selecting priority when adding tasks
- show color-coded priority badges and order tasks by due date then priority

## Testing
- `php -l index.php add_task.php db.php`


------
https://chatgpt.com/codex/tasks/task_e_68974340dbb483269651cc7995936e27