### PR TITLE
Prevent null warnings in task display

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <div class="container">
         <span class="navbar-brand mb-0 h1">Todo App</span>
         <div class="d-flex align-items-center">
-            <span class="me-3">Hello, <?=htmlspecialchars($_SESSION['username'])?></span>
+            <span class="me-3">Hello, <?=htmlspecialchars($_SESSION['username'] ?? '')?></span>
             <a href="logout.php" class="btn btn-outline-secondary btn-sm">Logout</a>
         </div>
     </div>
@@ -37,8 +37,8 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <div class="list-group">
         <?php foreach ($tasks as $task): ?>
             <a href="task.php?id=<?=$task['id']?>" class="list-group-item list-group-item-action d-flex justify-content-between">
-                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'])?></span>
-                <span class="text-muted"><?=htmlspecialchars($task['due_date'])?></span>
+                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'] ?? '')?></span>
+                <span class="text-muted"><?=htmlspecialchars($task['due_date'] ?? '')?></span>
             </a>
         <?php endforeach; ?>
     </div>

--- a/task.php
+++ b/task.php
@@ -50,15 +50,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <form method="post">
         <div class="mb-3">
             <label class="form-label">Title</label>
-            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars($task['description'])?>" required>
+            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars($task['description'] ?? '')?>" required>
         </div>
         <div class="mb-3">
             <label class="form-label">Due Date</label>
-            <input type="date" name="due_date" class="form-control" value="<?=htmlspecialchars($task['due_date'])?>">
+            <input type="date" name="due_date" class="form-control" value="<?=htmlspecialchars($task['due_date'] ?? '')?>">
         </div>
         <div class="mb-3">
             <label class="form-label">Description</label>
-            <textarea name="details" class="form-control" rows="4"><?=htmlspecialchars($task['details'])?></textarea>
+            <textarea name="details" class="form-control" rows="4"><?=htmlspecialchars($task['details'] ?? '')?></textarea>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-success ms-2"><?=$task['done'] ? 'Undo' : 'Done'?></a>


### PR DESCRIPTION
## Summary
- Guard against null values before calling `htmlspecialchars`
- Avoid PHP 8.1 deprecation warnings on empty `details` or `due_date`

## Testing
- `php -l index.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_68974408cf908326a56b34369c5042d4