### PR TITLE
Simplify task creation and enable priority editing

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -7,20 +7,11 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $description = trim($_POST['description'] ?? '');
-$due_date = trim($_POST['due_date'] ?? '');
-$details = trim($_POST['details'] ?? '');
-$priority = (int)($_POST['priority'] ?? 2);
-if ($priority < 1 || $priority > 3) {
-    $priority = 2;
-}
 if ($description !== '') {
-    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description, due_date, details, priority) VALUES (:uid, :description, :due_date, :details, :priority)');
+    $stmt = get_db()->prepare('INSERT INTO tasks (user_id, description) VALUES (:uid, :description)');
     $stmt->execute([
         ':uid' => $_SESSION['user_id'],
         ':description' => $description,
-        ':due_date' => $due_date !== '' ? $due_date : null,
-        ':details' => $details !== '' ? $details : null,
-        ':priority' => $priority,
     ]);
 }
 

--- a/index.php
+++ b/index.php
@@ -34,24 +34,8 @@ $priority_classes = [1 => 'bg-success', 2 => 'bg-warning', 3 => 'bg-danger'];
 </nav>
 <div class="container">
     <form action="add_task.php" method="post" class="mb-3">
-        <div class="mb-2">
-            <input type="text" name="description" class="form-control" placeholder="New task" required>
-        </div>
-        <div class="mb-2">
-            <input type="date" name="due_date" class="form-control" placeholder="Due date">
-        </div>
-        <div class="mb-2">
-            <select name="priority" class="form-select">
-                <option value="3">High</option>
-                <option value="2" selected>Medium</option>
-                <option value="1">Low</option>
-            </select>
-        </div>
-        <div class="mb-2">
-            <textarea name="details" class="form-control" placeholder="Description"></textarea>
-        </div>
-        <button class="btn btn-primary" type="submit">Add</button>
-
+        <input type="text" name="description" class="form-control" placeholder="New task" required>
+        <input type="submit" hidden>
     </form>
     <div class="list-group">
         <?php foreach ($tasks as $task): ?>

--- a/task.php
+++ b/task.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['user_id'])) {
 
 $db = get_db();
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$stmt = $db->prepare('SELECT id, description, due_date, details, done FROM tasks WHERE id = :id AND user_id = :uid');
+$stmt = $db->prepare('SELECT id, description, due_date, details, done, priority FROM tasks WHERE id = :id AND user_id = :uid');
 $stmt->execute([':id' => $id, ':uid' => $_SESSION['user_id']]);
 $task = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$task) {
@@ -20,11 +20,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $description = trim($_POST['description'] ?? '');
     $due_date = trim($_POST['due_date'] ?? '');
     $details = trim($_POST['details'] ?? '');
-    $stmt = $db->prepare('UPDATE tasks SET description = :description, due_date = :due_date, details = :details WHERE id = :id AND user_id = :uid');
+    $priority = (int)($_POST['priority'] ?? 2);
+    if ($priority < 1 || $priority > 3) {
+        $priority = 2;
+    }
+    $stmt = $db->prepare('UPDATE tasks SET description = :description, due_date = :due_date, details = :details, priority = :priority WHERE id = :id AND user_id = :uid');
     $stmt->execute([
         ':description' => $description,
         ':due_date' => $due_date !== '' ? $due_date : null,
         ':details' => $details !== '' ? $details : null,
+        ':priority' => $priority,
         ':id' => $id,
         ':uid' => $_SESSION['user_id'],
     ]);
@@ -55,6 +60,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="mb-3">
             <label class="form-label">Due Date</label>
             <input type="date" name="due_date" class="form-control" value="<?=htmlspecialchars($task['due_date'] ?? '')?>">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Priority</label>
+            <select name="priority" class="form-select">
+                <option value="3" <?php if (($task['priority'] ?? 2) == 3) echo 'selected'; ?>>High</option>
+                <option value="2" <?php if (($task['priority'] ?? 2) == 2) echo 'selected'; ?>>Medium</option>
+                <option value="1" <?php if (($task['priority'] ?? 2) == 1) echo 'selected'; ?>>Low</option>
+            </select>
         </div>
         <div class="mb-3">
             <label class="form-label">Description</label>


### PR DESCRIPTION
## Summary
- Allow adding tasks with just a name and no extra fields
- Default task creation now sets due date, priority, and details later
- Task detail page now lets users set priority

## Testing
- `php -l index.php`
- `php -l add_task.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_68974720b54c832687d94c3db5585590