### PR TITLE
feat: add offcanvas menu

### DIFF
--- a/completed.php
+++ b/completed.php
@@ -27,15 +27,28 @@ $priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 
     </head>
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
-    <div class="container">
+    <div class="container d-flex justify-content-between align-items-center">
         <a href="index.php" class="navbar-brand">Todo App</a>
-        <div class="d-flex align-items-center gap-2">
-            <a href="index.php" class="btn btn-outline-secondary btn-sm">Active</a>
-            <span class="me-3">Hello, <?=htmlspecialchars($_SESSION['username'] ?? '')?></span>
-            <a href="logout.php" class="btn btn-outline-secondary btn-sm">Logout</a>
-        </div>
+        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
     </div>
     </nav>
+
+<div class="offcanvas offcanvas-start" tabindex="-1" id="menu" aria-labelledby="menuLabel">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="menuLabel">Menu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <p class="mb-4">Hello, <?=htmlspecialchars($_SESSION['username'] ?? '')?></p>
+        <div class="list-group">
+            <a href="index.php" class="list-group-item list-group-item-action">Active Tasks</a>
+            <a href="completed.php" class="list-group-item list-group-item-action">Completed Tasks</a>
+            <a href="logout.php" class="list-group-item list-group-item-action">Logout</a>
+        </div>
+    </div>
+</div>
 <div class="container">
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h5 class="mb-0">Completed Tasks</h5>
@@ -67,6 +80,7 @@ $priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 
     </div>
     <?php endif; ?>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
 

--- a/index.php
+++ b/index.php
@@ -24,15 +24,28 @@ $priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
-    <div class="container">
+    <div class="container d-flex justify-content-between align-items-center">
         <span class="navbar-brand mb-0 h1">Todo App</span>
-        <div class="d-flex align-items-center gap-2">
-            <a href="completed.php" class="btn btn-outline-secondary btn-sm">Completed</a>
-            <span class="me-3">Hello, <?=htmlspecialchars($_SESSION['username'] ?? '')?></span>
-            <a href="logout.php" class="btn btn-outline-secondary btn-sm">Logout</a>
-        </div>
+        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
     </div>
 </nav>
+
+<div class="offcanvas offcanvas-start" tabindex="-1" id="menu" aria-labelledby="menuLabel">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="menuLabel">Menu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <p class="mb-4">Hello, <?=htmlspecialchars($_SESSION['username'] ?? '')?></p>
+        <div class="list-group">
+            <a href="index.php" class="list-group-item list-group-item-action">Active Tasks</a>
+            <a href="completed.php" class="list-group-item list-group-item-action">Completed Tasks</a>
+            <a href="logout.php" class="list-group-item list-group-item-action">Logout</a>
+        </div>
+    </div>
+</div>
 <div class="container">
     <form action="add_task.php" method="post" class="mb-3">
         <input type="text" name="description" class="form-control" placeholder="New task" required>
@@ -55,5 +68,6 @@ $priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 
         <?php endforeach; ?>
     </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/task.php
+++ b/task.php
@@ -52,13 +52,28 @@ if ($p < 0 || $p > 3) { $p = 0; }
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
-    <div class="container">
+    <div class="container d-flex justify-content-between align-items-center">
         <a href="index.php" class="navbar-brand">Todo App</a>
-        <div class="d-flex align-items-center gap-2">
-            <a href="completed.php" class="btn btn-outline-secondary btn-sm">Completed</a>
-        </div>
+        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
     </div>
 </nav>
+
+<div class="offcanvas offcanvas-start" tabindex="-1" id="menu" aria-labelledby="menuLabel">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="menuLabel">Menu</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <p class="mb-4">Hello, <?=htmlspecialchars($_SESSION['username'] ?? '')?></p>
+        <div class="list-group">
+            <a href="index.php" class="list-group-item list-group-item-action">Active Tasks</a>
+            <a href="completed.php" class="list-group-item list-group-item-action">Completed Tasks</a>
+            <a href="logout.php" class="list-group-item list-group-item-action">Logout</a>
+        </div>
+    </div>
+</div>
 <div class="container">
     <form method="post">
         <div class="mb-3">
@@ -90,7 +105,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
         <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-danger ms-2">Delete</a>
     </form>
 </div>
-</body>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){
   const select = document.querySelector('select[name="priority"]');
@@ -106,4 +121,5 @@ if ($p < 0 || $p > 3) { $p = 0; }
   select.addEventListener('change', updateBadge);
 })();
 </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- replace navbar links with a hamburger-triggered offcanvas menu for navigation
- include new menu on index, completed, and task detail pages with links to active tasks, completed tasks, and logout
- load Bootstrap bundle to power the offcanvas behavior

## Testing
- `php -l index.php`
- `php -l completed.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6897eac1f6388326a1c1748103e5781c