### PR TITLE
Hide delete option behind overflow menu

### DIFF
--- a/task.php
+++ b/task.php
@@ -54,8 +54,11 @@ if ($p < 0 || $p > 3) { $p = 0; }
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container">
         <a href="index.php" class="navbar-brand">Todo App</a>
-        <div class="d-flex align-items-center gap-2">
-            <a href="completed.php" class="btn btn-outline-secondary btn-sm">Completed</a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary btn-sm" type="button" id="taskMenu" data-bs-toggle="dropdown" aria-expanded="false">&#x2026;</button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="taskMenu">
+                <li><a class="dropdown-item text-danger" href="delete_task.php?id=<?=$task['id']?>">Delete</a></li>
+            </ul>
         </div>
     </div>
 </nav>
@@ -87,10 +90,10 @@ if ($p < 0 || $p > 3) { $p = 0; }
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-success ms-2"><?=$task['done'] ? 'Undo' : 'Done'?></a>
-        <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-danger ms-2">Delete</a>
     </form>
 </div>
 </body>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){
   const select = document.querySelector('select[name="priority"]');


### PR DESCRIPTION
## Summary
- Replace prominent Delete button on task details page with a three-dot overflow menu in the navbar.
- Remove inline Delete button from the task form.
- Load Bootstrap's JavaScript bundle to support the dropdown menu.
- Remove the Completed link from the task details navbar.

## Testing
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6897eb142e788326994035b8c16afd7f