### PR TITLE
Rename app title to Otodo

### DIFF
--- a/completed.php
+++ b/completed.php
@@ -28,7 +28,7 @@ $priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container d-flex justify-content-between align-items-center">
-        <a href="index.php" class="navbar-brand">Todo App</a>
+        <a href="index.php" class="navbar-brand">Otodo</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/index.php
+++ b/index.php
@@ -29,7 +29,7 @@ $priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container d-flex justify-content-between align-items-center">
-        <span class="navbar-brand mb-0 h1">Todo App</span>
+        <span class="navbar-brand mb-0 h1">Otodo</span>
         <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#menu" aria-controls="menu">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/task.php
+++ b/task.php
@@ -53,7 +53,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container d-flex justify-content-between align-items-center">
-        <a href="index.php" class="navbar-brand">Todo App</a>
+        <a href="index.php" class="navbar-brand">Otodo</a>
         <div class="d-flex align-items-center gap-2">
             <a href="completed.php" class="btn btn-outline-secondary btn-sm">Completed</a>
             <div class="dropdown">


### PR DESCRIPTION
## Summary
- Update navigation bar branding from "Todo App" to "Otodo" in all pages.

## Testing
- `php -l index.php task.php completed.php`


------
https://chatgpt.com/codex/tasks/task_e_6897ee803eac8326b4dd473bfba4a4d0