### PR TITLE
Hide delete option behind overflow menu and color priority dropdown

### DIFF
--- a/task.php
+++ b/task.php
@@ -37,8 +37,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit();
 }
 
-$priority_labels = [0 => 'None', 1 => 'Low', 2 => 'Medium', 3 => 'High'];
-$priority_classes = [0 => 'bg-secondary', 1 => 'bg-success', 2 => 'bg-warning', 3 => 'bg-danger'];
+$priority_classes = [
+    0 => 'bg-secondary text-white',
+    1 => 'bg-success text-white',
+    2 => 'bg-warning text-dark',
+    3 => 'bg-danger text-white'
+];
 $p = (int)($task['priority'] ?? 0);
 if ($p < 0 || $p > 3) { $p = 0; }
 ?>
@@ -54,8 +58,11 @@ if ($p < 0 || $p > 3) { $p = 0; }
 <nav class="navbar navbar-light bg-white mb-4">
     <div class="container">
         <a href="index.php" class="navbar-brand">Todo App</a>
-        <div class="d-flex align-items-center gap-2">
-            <a href="completed.php" class="btn btn-outline-secondary btn-sm">Completed</a>
+        <div class="dropdown">
+            <button class="btn btn-outline-secondary btn-sm" type="button" id="taskMenu" data-bs-toggle="dropdown" aria-expanded="false">&#x2026;</button>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="taskMenu">
+                <li><a class="dropdown-item text-danger" href="delete_task.php?id=<?=$task['id']?>">Delete</a></li>
+            </ul>
         </div>
     </div>
 </nav>
@@ -70,15 +77,12 @@ if ($p < 0 || $p > 3) { $p = 0; }
             <input type="date" name="due_date" class="form-control" value="<?=htmlspecialchars($task['due_date'] ?? '')?>">
         </div>
         <div class="mb-3">
-            <label class="form-label d-flex align-items-center justify-content-between">
-                <span>Priority</span>
-                <span id="priorityBadge" class="badge <?=$priority_classes[$p]?>"><?=$priority_labels[$p]?></span>
-            </label>
-            <select name="priority" class="form-select">
-                <option value="0" <?php if (($task['priority'] ?? 0) == 0) echo 'selected'; ?>>None</option>
-                <option value="3" <?php if (($task['priority'] ?? 2) == 3) echo 'selected'; ?>>High</option>
-                <option value="2" <?php if (($task['priority'] ?? 2) == 2) echo 'selected'; ?>>Medium</option>
-                <option value="1" <?php if (($task['priority'] ?? 2) == 1) echo 'selected'; ?>>Low</option>
+            <label class="form-label">Priority</label>
+            <select name="priority" class="form-select <?=$priority_classes[$p]?>">
+                <option value="0" class="bg-secondary text-white" <?php if (($task['priority'] ?? 0) == 0) echo 'selected'; ?>>None</option>
+                <option value="3" class="bg-danger text-white" <?php if (($task['priority'] ?? 2) == 3) echo 'selected'; ?>>High</option>
+                <option value="2" class="bg-warning text-dark" <?php if (($task['priority'] ?? 2) == 2) echo 'selected'; ?>>Medium</option>
+                <option value="1" class="bg-success text-white" <?php if (($task['priority'] ?? 2) == 1) echo 'selected'; ?>>Low</option>
             </select>
         </div>
         <div class="mb-3">
@@ -87,23 +91,25 @@ if ($p < 0 || $p > 3) { $p = 0; }
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-success ms-2"><?=$task['done'] ? 'Undo' : 'Done'?></a>
-        <a href="delete_task.php?id=<?=$task['id']?>" class="btn btn-danger ms-2">Delete</a>
     </form>
 </div>
 </body>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){
   const select = document.querySelector('select[name="priority"]');
-  const badge = document.getElementById('priorityBadge');
-  if (!select || !badge) return;
-  const labels = {0: 'None', 1: 'Low', 2: 'Medium', 3: 'High'};
-  const classes = {0: 'bg-secondary', 1: 'bg-success', 2: 'bg-warning', 3: 'bg-danger'};
-  function updateBadge() {
+  if (!select) return;
+  const classes = {
+    0: 'bg-secondary text-white',
+    1: 'bg-success text-white',
+    2: 'bg-warning text-dark',
+    3: 'bg-danger text-white'
+  };
+  function updateSelect() {
     const val = parseInt(select.value, 10);
-    badge.textContent = labels[val] || 'None';
-    badge.className = 'badge ' + (classes[val] || classes[0]);
+    select.className = 'form-select ' + (classes[val] || classes[0]);
   }
-  select.addEventListener('change', updateBadge);
+  select.addEventListener('change', updateSelect);
 })();
 </script>
 </html>


### PR DESCRIPTION
## Summary
- Replace prominent Delete button on task details page with a three-dot overflow menu in the navbar.
- Remove inline Delete button from the task form.
- Load Bootstrap's JavaScript bundle to support the dropdown menu.
- Remove the Completed link from the task details navbar.
- Remove the priority badge and color the priority dropdown to match the previous badge colors.

## Testing
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6897eb142e788326994035b8c16afd7f