### PR TITLE
Enable autosave on task details

### DIFF
--- a/task.php
+++ b/task.php
@@ -33,7 +33,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         ':id' => $id,
         ':uid' => $_SESSION['user_id'],
     ]);
-    header('Location: index.php');
+    header('Content-Type: application/json');
+    echo json_encode(['status' => 'ok']);
     exit();
 }
 
@@ -108,8 +109,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
             <div id="detailsEditable" class="form-control" contenteditable="true"><?=nl2br(htmlspecialchars($task['details'] ?? ''))?></div>
             <input type="hidden" name="details" id="detailsInput" value="<?=htmlspecialchars($task['details'] ?? '')?>">
         </div>
-        <button type="submit" class="btn btn-primary">Save</button>
-        <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-success ms-2"><?=$task['done'] ? 'Undo' : 'Done'?></a>
+        <a href="toggle_task.php?id=<?=$task['id']?>" class="btn btn-success"><?=$task['done'] ? 'Undo' : 'Done'?></a>
     </form>
 </div>
 </body>
@@ -118,24 +118,49 @@ if ($p < 0 || $p > 3) { $p = 0; }
 (function(){
   const select = document.querySelector('select[name="priority"]');
   const badge = document.getElementById('priorityBadge');
-  if (!select || !badge) return;
-  const labels = {0: 'None', 1: 'Low', 2: 'Medium', 3: 'High'};
-  const classes = {0: 'bg-secondary', 1: 'bg-success', 2: 'bg-warning', 3: 'bg-danger'};
-  function updateBadge() {
-    const val = parseInt(select.value, 10);
-    badge.textContent = labels[val] || 'None';
-    badge.className = 'badge ' + (classes[val] || classes[0]);
+  if (select && badge) {
+    const labels = {0: 'None', 1: 'Low', 2: 'Medium', 3: 'High'};
+    const classes = {0: 'bg-secondary', 1: 'bg-success', 2: 'bg-warning', 3: 'bg-danger'};
+    function updateBadge() {
+      const val = parseInt(select.value, 10);
+      badge.textContent = labels[val] || 'None';
+      badge.className = 'badge ' + (classes[val] || classes[0]);
+    }
+    select.addEventListener('change', updateBadge);
   }
-  select.addEventListener('change', updateBadge);
-})();
 
-document.querySelector('form')?.addEventListener('submit', function () {
-  const editable = document.getElementById('detailsEditable');
-  const input = document.getElementById('detailsInput');
-  if (editable && input) {
-    input.value = editable.innerText.trim();
+  const form = document.querySelector('form');
+  if (!form) return;
+  let timer;
+
+  function scheduleSave() {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(sendSave, 500);
   }
-});
+
+  function sendSave(immediate = false) {
+    const editable = document.getElementById('detailsEditable');
+    const input = document.getElementById('detailsInput');
+    if (editable && input) {
+      input.value = editable.innerText.trim();
+    }
+    const data = new FormData(form);
+    if (immediate && navigator.sendBeacon) {
+      navigator.sendBeacon(window.location.href, data);
+    } else {
+      fetch(window.location.href, {method: 'POST', body: data});
+    }
+  }
+
+  form.addEventListener('input', scheduleSave);
+  form.addEventListener('change', scheduleSave);
+  form.addEventListener('submit', function(e){ e.preventDefault(); });
+  window.addEventListener('beforeunload', function(){
+    if (timer) {
+      sendSave(true);
+    }
+  });
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove manual save button on task page
- Add JavaScript to automatically POST task updates as user types or navigates away
- Adjust server response to return JSON for autosave requests

## Testing
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6897f10c705083269f3211020216e027