### PR TITLE
Capitalize task titles

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -7,7 +7,7 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 $db = get_db();
-$description = trim($_POST['description'] ?? '');
+$description = mb_convert_case(trim($_POST['description'] ?? ''), MB_CASE_TITLE, 'UTF-8');
 if ($description !== '') {
     // Determine today's date based on user location
     $tz = $_SESSION['location'] ?? null;

--- a/completed.php
+++ b/completed.php
@@ -66,7 +66,7 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
         <?php foreach ($tasks as $task): ?>
             <?php $p = (int)($task['priority'] ?? 0); if ($p < 0 || $p > 3) { $p = 0; } ?>
             <div class="list-group-item d-flex align-items-start list-group-item-action" onclick="location.href='task.php?id=<?=$task['id']?>'" style="cursor: pointer;">
-                <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars($task['description'] ?? '')?></span>
+                <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars(mb_convert_case($task['description'] ?? '', MB_CASE_TITLE, 'UTF-8'))?></span>
                 <span class="d-flex align-items-center gap-2 ms-3 flex-shrink-0 text-nowrap">
                     <?php if (!empty($task['due_date'])): ?>
                         <span class="text-muted small"><?=htmlspecialchars($task['due_date'])?></span>

--- a/index.php
+++ b/index.php
@@ -60,7 +60,7 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
         <?php foreach ($tasks as $task): ?>
             <?php $p = (int)($task['priority'] ?? 0); if ($p < 0 || $p > 3) { $p = 0; } ?>
             <a href="task.php?id=<?=$task['id']?>" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'] ?? '')?></span>
+                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars(mb_convert_case($task['description'] ?? '', MB_CASE_TITLE, 'UTF-8'))?></span>
                 <span class="d-flex align-items-center gap-2">
                     <span class="text-muted small due-date text-end"><?=htmlspecialchars($task['due_date'] ?? '')?></span>
                     <span class="badge <?=$priority_classes[$p]?> priority-badge"><?=$priority_labels[$p]?></span>

--- a/task.php
+++ b/task.php
@@ -17,7 +17,7 @@ if (!$task) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $description = trim($_POST['description'] ?? '');
+    $description = mb_convert_case(trim($_POST['description'] ?? ''), MB_CASE_TITLE, 'UTF-8');
     $due_date = trim($_POST['due_date'] ?? '');
     $details = trim($_POST['details'] ?? '');
     $priority = (int)($_POST['priority'] ?? 0);
@@ -125,7 +125,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
     <form method="post">
         <div class="mb-3">
             <label class="form-label">Title</label>
-            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars($task['description'] ?? '')?>" required autocapitalize="none">
+            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars(mb_convert_case($task['description'] ?? '', MB_CASE_TITLE, 'UTF-8'))?>" required autocapitalize="none">
         </div>
         <div class="mb-3 d-flex align-items-end gap-3">
             <div>


### PR DESCRIPTION
## Summary
- Ensure task descriptions are saved and displayed with every word capitalized

## Testing
- `php -l add_task.php`
- `php -l completed.php`
- `php -l index.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6897fee800c48326bd5a2feb3c71e679