### PR TITLE
Add dynamic line formatting for task descriptions

### DIFF
--- a/db.php
+++ b/db.php
@@ -11,7 +11,8 @@ function get_db() {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
-            location TEXT
+            location TEXT,
+            dynamic_formatting INTEGER NOT NULL DEFAULT 1
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -37,10 +38,13 @@ function get_db() {
             $db->exec('ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 2');
         }
 
-        // Ensure location column exists for users
+        // Ensure user columns exist for older databases
         $userColumns = $db->query('PRAGMA table_info(users)')->fetchAll(PDO::FETCH_COLUMN, 1);
         if (!in_array('location', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN location TEXT');
+        }
+        if (!in_array('dynamic_formatting', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN dynamic_formatting INTEGER NOT NULL DEFAULT 1');
         }
     }
     return $db;

--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -1,0 +1,26 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (!window.dynamicFormattingEnabled) return;
+  document.querySelectorAll('input[name="description"]').forEach((el) => {
+    const update = () => {
+      const val = el.value;
+      if (val.startsWith('T ')) {
+        el.style.color = 'blue';
+        if (val.length > 2) {
+          const capital = val.charAt(2).toUpperCase();
+          const rest = val.slice(3);
+          const newVal = 'T ' + capital + rest;
+          if (newVal !== val) {
+            const pos = el.selectionStart;
+            el.value = newVal;
+            el.setSelectionRange(pos, pos);
+          }
+        }
+      } else {
+        el.style.color = '';
+      }
+    };
+    el.addEventListener('input', update);
+    update();
+  });
+});
+

--- a/index.php
+++ b/index.php
@@ -81,6 +81,10 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
         <?php endforeach; ?>
     </div>
 </div>
+<script>
+window.dynamicFormattingEnabled = <?=(int)($_SESSION['dynamic_formatting'] ?? 1)?>;
+</script>
+<script src="dynamic-formatting.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/login.php
+++ b/login.php
@@ -13,13 +13,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, dynamic_formatting FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
+            $_SESSION['dynamic_formatting'] = (int)($user['dynamic_formatting'] ?? 1);
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password) VALUES (:username, :password)');
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, dynamic_formatting) VALUES (:username, :password, 1)');
             $stmt->execute([':username' => $username, ':password' => $hash]);
             header('Location: login.php');
             exit();

--- a/settings.php
+++ b/settings.php
@@ -9,16 +9,20 @@ if (!isset($_SESSION['user_id'])) {
 $db = get_db();
 $message = '';
 $location = $_SESSION['location'] ?? '';
+$dynamic_formatting = (int)($_SESSION['dynamic_formatting'] ?? 1);
 $timezones = DateTimeZone::listIdentifiers();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $location = trim($_POST['location'] ?? '');
-    $stmt = $db->prepare('UPDATE users SET location = :loc WHERE id = :id');
+    $dynamic_formatting = isset($_POST['dynamic_formatting']) ? 1 : 0;
+    $stmt = $db->prepare('UPDATE users SET location = :loc, dynamic_formatting = :dyn WHERE id = :id');
     $stmt->execute([
         ':loc' => $location !== '' ? $location : null,
+        ':dyn' => $dynamic_formatting,
         ':id' => $_SESSION['user_id'],
     ]);
     $_SESSION['location'] = $location !== '' ? $location : 'UTC';
+    $_SESSION['dynamic_formatting'] = $dynamic_formatting;
     $message = 'Settings saved';
 }
 ?>
@@ -69,6 +73,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <?php endforeach; ?>
             </datalist>
             <button type="button" class="btn btn-outline-secondary mt-2" id="detect-tz">Use My Timezone</button>
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" name="dynamic_formatting" id="dynamicFormatting" <?php if ($dynamic_formatting) echo 'checked'; ?>>
+            <label class="form-check-label" for="dynamicFormatting">Enable Dynamic Line Formatting</label>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="index.php" class="btn btn-secondary">Back</a>

--- a/task.php
+++ b/task.php
@@ -154,6 +154,10 @@ if ($p < 0 || $p > 3) { $p = 0; }
         <a href="index.php" class="btn btn-secondary">Back</a>
     </form>
 </div>
+<script>
+window.dynamicFormattingEnabled = <?=(int)($_SESSION['dynamic_formatting'] ?? 1)?>;
+</script>
+<script src="dynamic-formatting.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){


### PR DESCRIPTION
## Summary
- highlight description lines starting with `T ` in blue and auto-capitalize following character
- allow users to enable or disable dynamic line formatting in settings
- persist dynamic formatting preference per user in database

## Testing
- `php -l db.php`
- `php -l register.php`
- `php -l login.php`
- `php -l settings.php`
- `php -l index.php`
- `php -l task.php`
- `node --check dynamic-formatting.js`


------
https://chatgpt.com/codex/tasks/task_e_6898042c22808326bd7b71819461cd45