### PR TITLE
Add dynamic line formatting for task descriptions

### DIFF
--- a/db.php
+++ b/db.php
@@ -11,7 +11,8 @@ function get_db() {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
-            location TEXT
+            location TEXT,
+            dynamic_formatting INTEGER NOT NULL DEFAULT 1
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -37,10 +38,13 @@ function get_db() {
             $db->exec('ALTER TABLE tasks ADD COLUMN priority INTEGER NOT NULL DEFAULT 2');
         }
 
-        // Ensure location column exists for users
+        // Ensure user columns exist for older databases
         $userColumns = $db->query('PRAGMA table_info(users)')->fetchAll(PDO::FETCH_COLUMN, 1);
         if (!in_array('location', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN location TEXT');
+        }
+        if (!in_array('dynamic_formatting', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN dynamic_formatting INTEGER NOT NULL DEFAULT 1');
         }
     }
     return $db;

--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -1,0 +1,94 @@
+(() => {
+  function init() {
+    if (!window.dynamicFormattingEnabled) return;
+    const el = document.getElementById('detailsEditable');
+    if (!el) return;
+    const hidden = document.getElementById('detailsInput');
+
+    function capitalizeFirst(str) {
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    function getCaret(root) {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return 0;
+      const range = sel.getRangeAt(0);
+      let caret = 0;
+      function traverse(node) {
+        if (node === range.endContainer) {
+          caret += range.endOffset;
+          return true;
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+          caret += node.textContent.length;
+        } else if (node.nodeName === 'BR') {
+          caret += 1;
+        }
+        for (const child of node.childNodes) {
+          if (traverse(child)) return true;
+        }
+        return false;
+      }
+      traverse(root);
+      return caret;
+    }
+
+    function setCaret(root, pos) {
+      const selection = window.getSelection();
+      const range = document.createRange();
+      let current = 0;
+      function traverse(node) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          const next = current + node.textContent.length;
+          if (pos <= next) {
+            range.setStart(node, pos - current);
+            return true;
+          }
+          current = next;
+        } else if (node.nodeName === 'BR') {
+          if (pos <= current + 1) {
+            range.setStartAfter(node);
+            return true;
+          }
+          current += 1;
+        } else {
+          for (const child of node.childNodes) {
+            if (traverse(child)) return true;
+          }
+        }
+        return false;
+      }
+      traverse(root);
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+
+    function update() {
+      const caret = getCaret(el);
+      const lines = el.textContent.split(/\n/);
+      const formatted = lines.map(line => {
+        if (line.startsWith('T ')) {
+          const rest = capitalizeFirst(line.slice(2));
+          return `<span style="color:blue;">T ${rest}</span>`;
+        }
+        return line ? capitalizeFirst(line) : '';
+      });
+      const html = formatted.join('<br>');
+      if (el.innerHTML !== html) {
+        el.innerHTML = html;
+        setCaret(el, caret);
+      }
+      if (hidden) hidden.value = el.textContent;
+    }
+
+    el.addEventListener('input', update);
+    update();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/index.php
+++ b/index.php
@@ -81,6 +81,10 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
         <?php endforeach; ?>
     </div>
 </div>
+<script>
+window.dynamicFormattingEnabled = <?=(int)($_SESSION['dynamic_formatting'] ?? 1)?>;
+</script>
+<script src="dynamic-formatting.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/login.php
+++ b/login.php
@@ -13,13 +13,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, dynamic_formatting FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
+            $_SESSION['dynamic_formatting'] = (int)($user['dynamic_formatting'] ?? 1);
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password) VALUES (:username, :password)');
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, dynamic_formatting) VALUES (:username, :password, 1)');
             $stmt->execute([':username' => $username, ':password' => $hash]);
             header('Location: login.php');
             exit();

--- a/settings.php
+++ b/settings.php
@@ -9,16 +9,20 @@ if (!isset($_SESSION['user_id'])) {
 $db = get_db();
 $message = '';
 $location = $_SESSION['location'] ?? '';
+$dynamic_formatting = (int)($_SESSION['dynamic_formatting'] ?? 1);
 $timezones = DateTimeZone::listIdentifiers();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $location = trim($_POST['location'] ?? '');
-    $stmt = $db->prepare('UPDATE users SET location = :loc WHERE id = :id');
+    $dynamic_formatting = isset($_POST['dynamic_formatting']) ? 1 : 0;
+    $stmt = $db->prepare('UPDATE users SET location = :loc, dynamic_formatting = :dyn WHERE id = :id');
     $stmt->execute([
         ':loc' => $location !== '' ? $location : null,
+        ':dyn' => $dynamic_formatting,
         ':id' => $_SESSION['user_id'],
     ]);
     $_SESSION['location'] = $location !== '' ? $location : 'UTC';
+    $_SESSION['dynamic_formatting'] = $dynamic_formatting;
     $message = 'Settings saved';
 }
 ?>
@@ -69,6 +73,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <?php endforeach; ?>
             </datalist>
             <button type="button" class="btn btn-outline-secondary mt-2" id="detect-tz">Use My Timezone</button>
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" name="dynamic_formatting" id="dynamicFormatting" <?php if ($dynamic_formatting) echo 'checked'; ?>>
+            <label class="form-check-label" for="dynamicFormatting">Enable Dynamic Line Formatting</label>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="index.php" class="btn btn-secondary">Back</a>

--- a/task.php
+++ b/task.php
@@ -154,6 +154,10 @@ if ($p < 0 || $p > 3) { $p = 0; }
         <a href="index.php" class="btn btn-secondary">Back</a>
     </form>
 </div>
+<script>
+window.dynamicFormattingEnabled = <?=(int)($_SESSION['dynamic_formatting'] ?? 1)?>;
+</script>
+<script src="dynamic-formatting.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){


### PR DESCRIPTION
## Summary
- highlight description lines starting with `T ` in blue and auto-capitalize following character
- capitalize the first character of each description line
- allow users to enable or disable dynamic line formatting in settings
- persist dynamic formatting preference per user in database
- ensure dynamic formatting initializes even after page load and syncs hidden field
- handle caret around line breaks so Enter and Delete keys behave normally

## Testing
- `node --check dynamic-formatting.js`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_6898042c22808326bd7b71819461cd45