### PR TITLE
Preserve line breaks in dynamic formatting

### DIFF
--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -66,7 +66,7 @@
 
     function update() {
       const caret = getCaret(el);
-      const text = el.textContent;
+      const text = el.innerText;
       const lines = text.split(/\n/);
 
       const formatted = lines.map(line => {
@@ -83,7 +83,7 @@
         el.innerHTML = html;
         setCaret(el, caret);
       }
-      if (hidden) hidden.value = el.textContent;
+      if (hidden) hidden.value = text;
     }
 
     el.addEventListener('input', update);


### PR DESCRIPTION
## Summary
- read editable content via `innerText` to retain `<div>`-based line breaks and store the same text in the hidden input
- keep trailing newline support by appending `<br>` when `innerText` ends with a newline

## Testing
- `node --check dynamic-formatting.js`
- `node - <<'NODE'
const fs = require('fs');
const {JSDOM} = require('jsdom');
const html = `<!DOCTYPE html><div id="detailsEditable" contenteditable="true"></div><input type="hidden" id="detailsInput">`;
const dom = new JSDOM(html, { runScripts: 'dangerously' });
Object.defineProperty(dom.window.HTMLElement.prototype, 'innerText', {configurable:true,get(){return this.textContent;},set(v){this.textContent=v;}});
dom.window.dynamicFormattingEnabled = true;
const script = fs.readFileSync('dynamic-formatting.js', 'utf-8');
dom.window.eval(script);
const event = dom.window.document.createEvent('Event');
event.initEvent('DOMContentLoaded', true, true);
dom.window.document.dispatchEvent(event);
const el = dom.window.document.getElementById('detailsEditable');
const hidden = dom.window.document.getElementById('detailsInput');
el.innerText = 'foo\nbar';
el.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
console.log('innerHTML:', JSON.stringify(el.innerHTML));
console.log('hidden:', JSON.stringify(hidden.value));
el.innerText = 'foo\n';
el.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
console.log('innerHTML trailing:', JSON.stringify(el.innerHTML));
console.log('hidden trailing:', JSON.stringify(hidden.value));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6898181e4ca88326b7e4bb69e30afcfa