### PR TITLE
Skip formatting on delete/backspace

### DIFF
--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -73,7 +73,7 @@
         updating = true;
         const caret = getCaret(el);
         let text = el.innerText;
-        const trailing = text.endsWith('\n\n');
+        const trailing = text.endsWith('\n');
         text = text.replace(/\n$/, '');
         const lines = text.split(/\n/);
 
@@ -99,8 +99,16 @@
         if (hidden) hidden.value = text;
       }
 
-
-    el.addEventListener('input', update);
+    el.addEventListener('input', (e) => {
+      if (e.inputType === 'deleteContentBackward' || e.inputType === 'deleteContentForward') {
+        if (hidden) {
+          const t = el.innerText.replace(/\n$/, '');
+          hidden.value = t;
+        }
+        return;
+      }
+      update();
+    });
     update();
   }
 


### PR DESCRIPTION
## Summary
- Skip dynamic formatting when the user presses Backspace or Delete
- Keep hidden input updated while allowing default delete/backspace behavior
- Preserve newline when pressing Enter so the cursor advances correctly

## Testing
- `node --check dynamic-formatting.js`


------
https://chatgpt.com/codex/tasks/task_e_6899e0ddf21c8326be2cca515a97f3f7