### PR TITLE
Add service worker for faster loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple PHP online todo list application with user authentication and SQLite st
 - Task priorities with color-coded badges
 - Tasks default to today's date
 - User-configurable location (timezone) for date calculations with browser auto-detection and a searchable list
+- Service worker caching for faster repeat visits
 
 ## Getting Started
 

--- a/completed.php
+++ b/completed.php
@@ -81,6 +81,7 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
     </div>
     <?php endif; ?>
 </div>
+<script src="sw-register.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -84,6 +84,7 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
 <script>
 window.dynamicFormattingEnabled = <?=(int)($_SESSION['dynamic_formatting'] ?? 1)?>;
 </script>
+<script src="sw-register.js"></script>
 <script src="dynamic-formatting.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/login.php
+++ b/login.php
@@ -56,5 +56,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </form>
     <p>Don't have an account? <a href="register.php">Register</a></p>
 </div>
+<script src="sw-register.js"></script>
 </body>
 </html>

--- a/register.php
+++ b/register.php
@@ -52,5 +52,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </form>
     <p>Already have an account? <a href="login.php">Login</a></p>
 </div>
+<script src="sw-register.js"></script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,45 @@
+const CACHE_NAME = 'otodo-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.php',
+  '/login.php',
+  '/register.php',
+  '/settings.php',
+  '/completed.php',
+  '/task.php',
+  '/dynamic-formatting.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).then(networkResponse => {
+        if (networkResponse && networkResponse.status === 200 && networkResponse.type === 'basic') {
+          const responseClone = networkResponse.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+        }
+        return networkResponse;
+      }).catch(() => caches.match('/'));
+    })
+  );
+});

--- a/settings.php
+++ b/settings.php
@@ -82,6 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <a href="index.php" class="btn btn-secondary">Back</a>
     </form>
 </div>
+<script src="sw-register.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 const input = document.getElementById('location');

--- a/sw-register.js
+++ b/sw-register.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}

--- a/task.php
+++ b/task.php
@@ -207,5 +207,6 @@ window.dynamicFormattingEnabled = <?=(int)($_SESSION['dynamic_formatting'] ?? 1)
   });
 })();
 </script>
+<script src="sw-register.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add service worker to precache core pages and assets
- Register the worker across app pages
- Document service worker caching in README

## Testing
- `php -l index.php`
- `php -l completed.php`
- `php -l settings.php`
- `php -l login.php`
- `php -l register.php`
- `php -l task.php`
- `node --check service-worker.js`
- `node --check sw-register.js`


------
https://chatgpt.com/codex/tasks/task_e_689fecb7dc5c8326ab1420fd3ec8af10