### PR TITLE
Use network-first caching for dynamic pages

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,9 @@
-const CACHE_NAME = 'otodo-cache-v1';
+const CACHE_NAME = 'otodo-cache-v2';
 const URLS_TO_CACHE = [
   '/',
-  '/index.php',
   '/login.php',
   '/register.php',
   '/settings.php',
-  '/completed.php',
-  '/task.php',
   '/dynamic-formatting.js'
 ];
 
@@ -28,6 +25,19 @@ self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') {
     return;
   }
+
+  const url = new URL(event.request.url);
+  const isNavigational =
+    event.request.mode === 'navigate' ||
+    ['/index.php', '/task.php', '/completed.php'].some(path => url.pathname.endsWith(path));
+
+  if (isNavigational) {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then(response => {
       if (response) {


### PR DESCRIPTION
## Summary
- Use a network-first strategy for navigational requests in the service worker
- Exclude dynamic PHP pages from the precache list and bump cache version

## Testing
- `node --check service-worker.js`
- `curl -b cookies.txt http://127.0.0.1:8000/index.php | grep -n "2030"` (server-side verification of updated due date)


------
https://chatgpt.com/codex/tasks/task_e_689fef8b62348326b491654b30e07315