### PR TITLE
Allow configuring default task priority

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -26,12 +26,13 @@ if ($description !== '') {
     }
     $due_date = $now->format('Y-m-d');
 
-    // Default new tasks to no priority (0)
+    // Insert new task using user's default priority
+    $priority = (int)($_SESSION['default_priority'] ?? 0);
     $stmt = $db->prepare('INSERT INTO tasks (user_id, description, priority, due_date) VALUES (:uid, :description, :priority, :due_date)');
     $stmt->execute([
         ':uid' => $_SESSION['user_id'],
         ':description' => $description,
-        ':priority' => 0,
+        ':priority' => $priority,
         ':due_date' => $due_date,
     ]);
 }

--- a/db.php
+++ b/db.php
@@ -12,7 +12,8 @@ function get_db() {
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
             location TEXT,
-            dynamic_formatting INTEGER NOT NULL DEFAULT 1
+            dynamic_formatting INTEGER NOT NULL DEFAULT 1,
+            default_priority INTEGER NOT NULL DEFAULT 0
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -45,6 +46,9 @@ function get_db() {
         }
         if (!in_array('dynamic_formatting', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN dynamic_formatting INTEGER NOT NULL DEFAULT 1');
+        }
+        if (!in_array('default_priority', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
         }
     }
     return $db;

--- a/login.php
+++ b/login.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, dynamic_formatting FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, dynamic_formatting, default_priority FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -21,6 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
             $_SESSION['dynamic_formatting'] = (int)($user['dynamic_formatting'] ?? 1);
+            $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -15,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, dynamic_formatting) VALUES (:username, :password, 1)');
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, dynamic_formatting, default_priority) VALUES (:username, :password, 1, 0)');
             $stmt->execute([':username' => $username, ':password' => $hash]);
             header('Location: login.php');
             exit();

--- a/settings.php
+++ b/settings.php
@@ -10,19 +10,26 @@ $db = get_db();
 $message = '';
 $location = $_SESSION['location'] ?? '';
 $dynamic_formatting = (int)($_SESSION['dynamic_formatting'] ?? 1);
+$default_priority = (int)($_SESSION['default_priority'] ?? 0);
 $timezones = DateTimeZone::listIdentifiers();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $location = trim($_POST['location'] ?? '');
     $dynamic_formatting = isset($_POST['dynamic_formatting']) ? 1 : 0;
-    $stmt = $db->prepare('UPDATE users SET location = :loc, dynamic_formatting = :dyn WHERE id = :id');
+    $default_priority = (int)($_POST['default_priority'] ?? 0);
+    if ($default_priority < 0 || $default_priority > 3) {
+        $default_priority = 0;
+    }
+    $stmt = $db->prepare('UPDATE users SET location = :loc, dynamic_formatting = :dyn, default_priority = :pri WHERE id = :id');
     $stmt->execute([
         ':loc' => $location !== '' ? $location : null,
         ':dyn' => $dynamic_formatting,
+        ':pri' => $default_priority,
         ':id' => $_SESSION['user_id'],
     ]);
     $_SESSION['location'] = $location !== '' ? $location : 'UTC';
     $_SESSION['dynamic_formatting'] = $dynamic_formatting;
+    $_SESSION['default_priority'] = $default_priority;
     $message = 'Settings saved';
 }
 ?>
@@ -77,6 +84,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="form-check mb-3">
             <input class="form-check-input" type="checkbox" name="dynamic_formatting" id="dynamicFormatting" <?php if ($dynamic_formatting) echo 'checked'; ?>>
             <label class="form-check-label" for="dynamicFormatting">Enable Dynamic Line Formatting</label>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="default_priority">Default Task Priority</label>
+            <select name="default_priority" id="default_priority" class="form-select">
+                <option value="3" <?php if ($default_priority == 3) echo 'selected'; ?>>High</option>
+                <option value="2" <?php if ($default_priority == 2) echo 'selected'; ?>>Medium</option>
+                <option value="1" <?php if ($default_priority == 1) echo 'selected'; ?>>Low</option>
+                <option value="0" <?php if ($default_priority == 0) echo 'selected'; ?>>None</option>
+            </select>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="index.php" class="btn btn-secondary">Back</a>


### PR DESCRIPTION
## Summary
- add `default_priority` column to users and migration logic
- allow selecting default priority on Settings page
- use configured default when creating new tasks

## Testing
- `php -l db.php`
- `php -l login.php`
- `php -l register.php`
- `php -l settings.php`
- `php -l add_task.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0022341048326bb61fe92508e6508