### PR TITLE
Use relative wording and colors for due dates

### DIFF
--- a/completed.php
+++ b/completed.php
@@ -64,12 +64,42 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
     <?php else: ?>
     <div class="list-group">
         <?php foreach ($tasks as $task): ?>
-            <?php $p = (int)($task['priority'] ?? 0); if ($p < 0 || $p > 3) { $p = 0; } ?>
+            <?php
+                $p = (int)($task['priority'] ?? 0);
+                if ($p < 0 || $p > 3) { $p = 0; }
+                $due = $task['due_date'] ?? '';
+                $dueClass = 'text-muted';
+                if ($due !== '') {
+                    try {
+                        $dueDate = new DateTime($due);
+                        $today = new DateTime('today');
+                        $tomorrow = (clone $today)->modify('+1 day');
+                        if ($dueDate < $today) {
+                            $due = 'Overdue';
+                            $dueClass = 'text-danger';
+                        } else {
+                            $dueFmt = $dueDate->format('Y-m-d');
+                            if ($dueFmt === $today->format('Y-m-d')) {
+                                $due = 'Today';
+                                $dueClass = 'text-success';
+                            } elseif ($dueFmt === $tomorrow->format('Y-m-d')) {
+                                $due = 'Tomorrow';
+                                $dueClass = 'text-primary';
+                            } else {
+                                $due = 'Later';
+                                $dueClass = 'text-primary';
+                            }
+                        }
+                    } catch (Exception $e) {
+                        // leave $due unchanged if parsing fails
+                    }
+                }
+            ?>
             <div class="list-group-item d-flex align-items-start list-group-item-action" onclick="location.href='task.php?id=<?=$task['id']?>'" style="cursor: pointer;">
                 <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?></span>
                 <span class="d-flex align-items-center gap-2 ms-3 flex-shrink-0 text-nowrap">
-                    <?php if (!empty($task['due_date'])): ?>
-                        <span class="text-muted small"><?=htmlspecialchars($task['due_date'])?></span>
+                    <?php if ($due !== ''): ?>
+                        <span class="small <?=$dueClass?>"><?=htmlspecialchars($due)?></span>
                     <?php endif; ?>
                     <?php if ($p > 0): ?>
                         <span class="badge <?=$priority_classes[$p]?>"><?=$priority_labels[$p]?></span>

--- a/index.php
+++ b/index.php
@@ -62,9 +62,28 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
                 $p = (int)($task['priority'] ?? 0);
                 if ($p < 0 || $p > 3) { $p = 0; }
                 $due = $task['due_date'] ?? '';
+                $dueClass = 'text-muted';
                 if ($due !== '') {
                     try {
-                        $due = (new DateTime($due))->format('j M Y');
+                        $dueDate = new DateTime($due);
+                        $today = new DateTime('today');
+                        $tomorrow = (clone $today)->modify('+1 day');
+                        if ($dueDate < $today) {
+                            $due = 'Overdue';
+                            $dueClass = 'text-danger';
+                        } else {
+                            $dueFmt = $dueDate->format('Y-m-d');
+                            if ($dueFmt === $today->format('Y-m-d')) {
+                                $due = 'Today';
+                                $dueClass = 'text-success';
+                            } elseif ($dueFmt === $tomorrow->format('Y-m-d')) {
+                                $due = 'Tomorrow';
+                                $dueClass = 'text-primary';
+                            } else {
+                                $due = 'Later';
+                                $dueClass = 'text-primary';
+                            }
+                        }
                     } catch (Exception $e) {
                         // leave $due unchanged if parsing fails
                     }
@@ -73,7 +92,7 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
             <a href="task.php?id=<?=$task['id']?>" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
                 <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?></span>
                 <span class="d-flex align-items-center gap-2">
-                    <span class="text-muted small due-date text-end"><?=htmlspecialchars($due)?></span>
+                    <span class="small due-date text-end <?=$dueClass?>"><?=htmlspecialchars($due)?></span>
                     <span class="badge <?=$priority_classes[$p]?> priority-badge"><?=$priority_labels[$p]?></span>
 
                 </span>


### PR DESCRIPTION
## Summary
- Capitalize relative due-date labels and include **Later** for future tasks
- Color-code due-date labels (red for overdue, green for today, blue for tomorrow and later)

## Testing
- `php -l index.php`
- `php -l completed.php`


------
https://chatgpt.com/codex/tasks/task_e_689fecd29aa0832685b4576889368d91