### PR TITLE
Add dynamic formatting test page with logging

### DIFF
--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -4,6 +4,9 @@
     const el = document.getElementById('detailsEditable');
     if (!el) return;
     const hidden = document.getElementById('detailsInput');
+    if (window.dynamicFormattingDebug) {
+      console.log('Dynamic formatting initialized');
+    }
 
     function capitalizeFirst(str) {
       return str.charAt(0).toUpperCase() + str.slice(1);
@@ -86,6 +89,10 @@
         });
         let html = formatted.join('<br>');
         if (trailing) html += '<br>';
+
+        if (window.dynamicFormattingDebug) {
+          console.log('update', { text, html, caret });
+        }
 
         if (el.innerHTML !== html) {
           el.innerHTML = html;

--- a/formatting_test.php
+++ b/formatting_test.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dynamic Formatting Test</title>
+  <style>
+    #detailsEditable {
+      border: 1px solid #ccc;
+      padding: 8px;
+      min-height: 100px;
+    }
+    #log {
+      border: 1px solid #ccc;
+      padding: 8px;
+      height: 150px;
+      overflow: auto;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dynamic Formatting Test Page</h1>
+  <div id="detailsEditable" contenteditable="true"></div>
+  <input type="hidden" id="detailsInput">
+  <h2>Log</h2>
+  <pre id="log"></pre>
+  <script>
+    window.dynamicFormattingEnabled = true;
+    window.dynamicFormattingDebug = true;
+    (function() {
+      const logEl = document.getElementById('log');
+      const origLog = console.log;
+      console.log = function(...args) {
+        origLog.apply(console, args);
+        const msg = args.map(a => {
+          if (typeof a === 'object') {
+            try { return JSON.stringify(a); } catch (e) { return '[Object]'; }
+          }
+          return String(a);
+        }).join(' ');
+        logEl.textContent += msg + '\n';
+      };
+    })();
+  </script>
+  <script src="dynamic-formatting.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- log initialization and update steps in dynamic-formatting.js when debug flag is set
- introduce formatting_test.php to exercise dynamic line formatting and capture logs

## Testing
- `node --check dynamic-formatting.js`
- `php -l formatting_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a069bb79e88326864ad1c91fad199a