### PR TITLE
Handle trailing newlines in dynamic formatting

### DIFF
--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -74,10 +74,14 @@
       function update() {
         if (updating) return;
         updating = true;
-        const caret = getCaret(el);
+        let caret = getCaret(el);
         let text = el.innerText;
+        if (text.endsWith('\n')) {
+          text = text.slice(0, -1);
+          if (caret > text.length) caret--;
+        }
         const trailing = text.endsWith('\n');
-        text = text.replace(/\n$/, '');
+        if (trailing) text = text.slice(0, -1);
         const lines = text.split(/\n/);
 
         const formatted = lines.map(line => {


### PR DESCRIPTION
## Summary
- Adjust update() to use mutable caret position
- Strip automatic trailing newline and handle user-typed newline separately

## Testing
- `node --check dynamic-formatting.js`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a07136ede08326861f6cc6b44e63c5