### PR TITLE
Fix trailing newline caret desync

### DIFF
--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -4,6 +4,9 @@
     const el = document.getElementById('detailsEditable');
     if (!el) return;
     const hidden = document.getElementById('detailsInput');
+    if (window.dynamicFormattingDebug) {
+      console.log('Dynamic formatting initialized');
+    }
 
     function capitalizeFirst(str) {
       return str.charAt(0).toUpperCase() + str.slice(1);
@@ -71,10 +74,14 @@
       function update() {
         if (updating) return;
         updating = true;
-        const caret = getCaret(el);
+        let caret = getCaret(el);
         let text = el.innerText;
+        if (text.endsWith('\n')) {
+          text = text.slice(0, -1);
+          if (caret > text.length) caret--;
+        }
         const trailing = text.endsWith('\n');
-        text = text.replace(/\n$/, '');
+        if (trailing) text = text.slice(0, -1);
         const lines = text.split(/\n/);
 
         const formatted = lines.map(line => {
@@ -87,6 +94,10 @@
         let html = formatted.join('<br>');
         if (trailing) html += '<br>';
 
+        if (window.dynamicFormattingDebug) {
+          console.log('update', { text, html, caret });
+        }
+
         if (el.innerHTML !== html) {
           el.innerHTML = html;
           setTimeout(() => {
@@ -96,7 +107,7 @@
         } else {
           updating = false;
         }
-        if (hidden) hidden.value = text;
+        if (hidden) hidden.value = text + (trailing ? '\n' : '');
       }
 
     el.addEventListener('input', (e) => {

--- a/formatting_test.php
+++ b/formatting_test.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dynamic Formatting Test</title>
+  <style>
+    #detailsEditable {
+      border: 1px solid #ccc;
+      padding: 8px;
+      min-height: 100px;
+    }
+    #log {
+      border: 1px solid #ccc;
+      padding: 8px;
+      height: 150px;
+      overflow: auto;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dynamic Formatting Test Page</h1>
+  <div id="detailsEditable" contenteditable="true"></div>
+  <input type="hidden" id="detailsInput">
+  <h2>Log</h2>
+  <pre id="log"></pre>
+  <script>
+    window.dynamicFormattingEnabled = true;
+    window.dynamicFormattingDebug = true;
+    (function() {
+      const logEl = document.getElementById('log');
+      const origLog = console.log;
+      console.log = function(...args) {
+        origLog.apply(console, args);
+        const msg = args.map(a => {
+          if (typeof a === 'object') {
+            try { return JSON.stringify(a); } catch (e) { return '[Object]'; }
+          }
+          return String(a);
+        }).join(' ');
+        logEl.textContent += msg + '\n';
+      };
+    })();
+  </script>
+  <script src="dynamic-formatting.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Synchronize caret and text when contenteditable adds an automatic newline
- Only insert `<br>` when user explicitly types a newline
- Preserve user-intended trailing newline in hidden input field

## Testing
- `node --check dynamic-formatting.js && echo 'JS syntax OK'`
- `php -l formatting_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a069bb79e88326864ad1c91fad199a