### PR TITLE
Fix trailing newline caret desync

### DIFF
--- a/dynamic-formatting.js
+++ b/dynamic-formatting.js
@@ -4,111 +4,145 @@
     const el = document.getElementById('detailsEditable');
     if (!el) return;
     const hidden = document.getElementById('detailsInput');
+    if (window.dynamicFormattingDebug) {
+      console.log('Dynamic formatting initialized');
+    }
+
+    function textToHtml(text) {
+      const escaped = text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      return escaped.replace(/\n/g, '<br>');
+    }
+
+    function htmlToText(html) {
+      const sanitized = html.replace(/(?:<br>\s*)+$/, '');
+      return sanitized
+        .replace(/<br\s*\/?>/gi, '\n')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&amp;/g, '&');
+    }
+
+    function createRangeAtTextOffset(root, offset) {
+      const range = document.createRange();
+      let remaining = offset;
+      const walker = document.createTreeWalker(
+        root,
+        NodeFilter.SHOW_ALL,
+        {
+          acceptNode(node) {
+            if (node.nodeType === Node.TEXT_NODE && node.nodeValue.length > 0) return NodeFilter.FILTER_ACCEPT;
+            if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === 'BR') return NodeFilter.FILTER_ACCEPT;
+            return NodeFilter.FILTER_SKIP;
+          }
+        }
+      );
+      let node;
+      while ((node = walker.nextNode())) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          const len = node.nodeValue.length;
+          if (remaining <= len) {
+            range.setStart(node, remaining);
+            range.collapse(true);
+            return range;
+          }
+          remaining -= len;
+        } else if (node.nodeName === 'BR') {
+          if (remaining === 0) {
+            range.setStartBefore(node);
+            range.collapse(true);
+            return range;
+          }
+          remaining -= 1;
+        }
+      }
+      range.selectNodeContents(root);
+      range.collapse(false);
+      return range;
+    }
+
+    function setCaretFromTextOffset(root, offset) {
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(createRangeAtTextOffset(root, offset));
+    }
+
+    function getTextOffsetFromSelection(root) {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return 0;
+      const range = sel.getRangeAt(0);
+      const walker = document.createTreeWalker(
+        root,
+        NodeFilter.SHOW_ALL,
+        {
+          acceptNode(node) {
+            if (node.nodeType === Node.TEXT_NODE && node.nodeValue.length > 0) return NodeFilter.FILTER_ACCEPT;
+            if (node.nodeType === Node.ELEMENT_NODE && node.nodeName === 'BR') return NodeFilter.FILTER_ACCEPT;
+            return NodeFilter.FILTER_SKIP;
+          }
+        }
+      );
+      let offset = 0;
+      let node;
+      while ((node = walker.nextNode())) {
+        if (node === range.startContainer && node.nodeType === Node.TEXT_NODE) {
+          offset += range.startOffset;
+          return offset;
+        }
+        const nodeRange = document.createRange();
+        nodeRange.selectNode(node);
+        if (range.compareBoundaryPoints(Range.END_TO_START, nodeRange) <= 0) {
+          return offset;
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+          offset += node.nodeValue.length;
+        } else if (node.nodeName === 'BR') {
+          offset += 1;
+        }
+      }
+      return offset;
+    }
 
     function capitalizeFirst(str) {
       return str.charAt(0).toUpperCase() + str.slice(1);
     }
 
-    function getCaret(root) {
-      const sel = window.getSelection();
-      if (!sel || sel.rangeCount === 0) return 0;
-      const range = sel.getRangeAt(0);
-      let caret = 0;
-      function traverse(node) {
-        if (node === range.endContainer) {
-          caret += range.endOffset;
-          return true;
+    function render(text) {
+      const lines = text.split('\n');
+      const formatted = lines.map(line => {
+        if (line.startsWith('T ')) {
+          const rest = capitalizeFirst(line.slice(2));
+          return `<span style="color:blue;">${textToHtml(`T ${rest}`)}</span>`;
         }
-        if (node.nodeType === Node.TEXT_NODE) {
-          caret += node.textContent.length;
-        } else {
-          for (const child of node.childNodes) {
-            if (traverse(child)) return true;
-          }
-          if (node.nodeName === 'BR' || (node.nodeName === 'DIV' && node !== root)) {
-            caret += 1;
-          }
-        }
-        return false;
-      }
-      traverse(root);
-      return caret;
+        return textToHtml(line ? capitalizeFirst(line) : '');
+      });
+      return formatted.join('<br>');
     }
 
-    function setCaret(root, pos) {
-      const selection = window.getSelection();
-      const range = document.createRange();
-      let current = 0;
-      function traverse(node) {
-        if (node.nodeType === Node.TEXT_NODE) {
-          const next = current + node.textContent.length;
-          if (pos <= next) {
-            range.setStart(node, pos - current);
-            return true;
-          }
-          current = next;
-        } else if (node.nodeName === 'BR') {
-          if (pos <= current + 1) {
-            range.setStartAfter(node);
-            return true;
-          }
-          current += 1;
-        } else {
-          for (const child of node.childNodes) {
-            if (traverse(child)) return true;
-          }
-        }
-        return false;
+    let updating = false;
+
+    function update() {
+      if (updating) return;
+      updating = true;
+      const caret = getTextOffsetFromSelection(el);
+      const rawHtml = el.innerHTML.replace(/<\/?span[^>]*>/g, '');
+      const text = htmlToText(rawHtml);
+      const html = render(text);
+      if (el.innerHTML !== html) {
+        el.innerHTML = html;
       }
-      traverse(root);
-      range.collapse(true);
-      selection.removeAllRanges();
-      selection.addRange(range);
+      const clamped = Math.max(0, Math.min(text.length, caret));
+      setCaretFromTextOffset(el, clamped);
+      if (hidden) hidden.value = text;
+      if (window.dynamicFormattingDebug) {
+        console.log('update', { text, html, caret: clamped });
+      }
+      updating = false;
     }
 
-      let updating = false;
-
-      function update() {
-        if (updating) return;
-        updating = true;
-        const caret = getCaret(el);
-        let text = el.innerText;
-        const trailing = text.endsWith('\n');
-        text = text.replace(/\n$/, '');
-        const lines = text.split(/\n/);
-
-        const formatted = lines.map(line => {
-          if (line.startsWith('T ')) {
-            const rest = capitalizeFirst(line.slice(2));
-            return `<span style="color:blue;">T ${rest}</span>`;
-          }
-          return line ? capitalizeFirst(line) : '';
-        });
-        let html = formatted.join('<br>');
-        if (trailing) html += '<br>';
-
-        if (el.innerHTML !== html) {
-          el.innerHTML = html;
-          setTimeout(() => {
-            setCaret(el, caret);
-            updating = false;
-          }, 0);
-        } else {
-          updating = false;
-        }
-        if (hidden) hidden.value = text;
-      }
-
-    el.addEventListener('input', (e) => {
-      if (e.inputType === 'deleteContentBackward' || e.inputType === 'deleteContentForward') {
-        if (hidden) {
-          const t = el.innerText.replace(/\n$/, '');
-          hidden.value = t;
-        }
-        return;
-      }
-      update();
-    });
+    el.addEventListener('input', update);
     update();
   }
 
@@ -118,3 +152,4 @@
     init();
   }
 })();
+

--- a/formatting_test.php
+++ b/formatting_test.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Dynamic Formatting Test</title>
+  <style>
+    #detailsEditable {
+      border: 1px solid #ccc;
+      padding: 8px;
+      min-height: 100px;
+    }
+    #log {
+      border: 1px solid #ccc;
+      padding: 8px;
+      height: 150px;
+      overflow: auto;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>Dynamic Formatting Test Page</h1>
+  <div id="detailsEditable" contenteditable="true"></div>
+  <input type="hidden" id="detailsInput">
+  <h2>Log</h2>
+  <pre id="log"></pre>
+  <script>
+    window.dynamicFormattingEnabled = true;
+    window.dynamicFormattingDebug = true;
+    (function() {
+      const logEl = document.getElementById('log');
+      const origLog = console.log;
+      console.log = function(...args) {
+        origLog.apply(console, args);
+        const msg = args.map(a => {
+          if (typeof a === 'object') {
+            try { return JSON.stringify(a); } catch (e) { return '[Object]'; }
+          }
+          return String(a);
+        }).join(' ');
+        logEl.textContent += msg + '\n';
+      };
+    })();
+  </script>
+  <script src="dynamic-formatting.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Map raw text to HTML and back so `\n` corresponds to a single `<br>`
- Add helpers to place/read caret using text offsets instead of DOM positions
- Rebuild editor content on each input while keeping hidden field and caret in sync

## Testing
- `node --check dynamic-formatting.js && echo 'JS syntax OK'`
- `php -l formatting_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68a069bb79e88326864ad1c91fad199a