### PR TITLE
Double task details textarea height on desktop

### DIFF
--- a/task.php
+++ b/task.php
@@ -86,6 +86,11 @@ if ($p < 0 || $p > 3) { $p = 0; }
             background-color: inherit !important;
             color: inherit !important;
         }
+        @media (min-width: 992px) {
+            #detailsInput {
+                min-height: 15rem;
+            }
+        }
     </style>
     <title>Task Details</title>
 </head>


### PR DESCRIPTION
## Summary
- Increase task description textarea height on desktop with a media query for better writing space

## Testing
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1ce49c47c8326bcd44b7cd2215449