### PR TITLE
Add customizable prefixes and auto-capitalization

### DIFF
--- a/add_task.php
+++ b/add_task.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['user_id'])) {
 
 $db = get_db();
 
-$description = ucwords(strtolower(trim($_POST['description'] ?? '')));
+$description = format_description(trim($_POST['description'] ?? ''));
 
 if ($description !== '') {
     // Determine today's date based on user location

--- a/add_task.php
+++ b/add_task.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['user_id'])) {
 
 $db = get_db();
 
-$description = ucwords(strtolower(trim($_POST['description'] ?? '')));
+$description = trim($_POST['description'] ?? '');
 
 if ($description !== '') {
     // Determine today's date based on user location

--- a/add_task.php
+++ b/add_task.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['user_id'])) {
 
 $db = get_db();
 
-$description = trim($_POST['description'] ?? '');
+$description = ucwords(strtolower(trim($_POST['description'] ?? '')));
 
 if ($description !== '') {
     // Determine today's date based on user location

--- a/capitalize.js
+++ b/capitalize.js
@@ -1,0 +1,31 @@
+(function(){
+  function capLines(text, prefixes){
+    return text.split(/\n/).map(function(line){
+      var leadingMatch = line.match(/^\s*/);
+      var leading = leadingMatch ? leadingMatch[0] : '';
+      var rest = line.slice(leading.length);
+      var prefix = '';
+      for (var i=0;i<prefixes.length;i++){
+        var p = prefixes[i];
+        if (p && rest.startsWith(p)){
+          prefix = p;
+          rest = rest.slice(p.length);
+          break;
+        }
+      }
+      rest = rest.replace(/^(\s*)(\S)/, function(m, ws, ch){ return ws + ch.toUpperCase(); });
+      return leading + prefix + rest;
+    }).join('\n');
+  }
+  window.setupAutoCapitalize = function(el, prefixes){
+    if (!el) return;
+    el.addEventListener('input', function(){
+      var pos = el.selectionStart;
+      var val = capLines(el.value, prefixes);
+      if (val !== el.value){
+        el.value = val;
+        el.setSelectionRange(pos, pos);
+      }
+    });
+  };
+})();

--- a/completed.php
+++ b/completed.php
@@ -105,7 +105,7 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
                 }
             ?>
             <div class="list-group-item d-flex align-items-start list-group-item-action" onclick="location.href='task.php?id=<?=$task['id']?>'" style="cursor: pointer;">
-                <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars($task['description'] ?? '')?></span>
+                <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?></span>
                 <span class="d-flex align-items-center gap-2 ms-3 flex-shrink-0 text-nowrap">
                     <?php if ($due !== ''): ?>
                         <span class="small <?=$dueClass?>"><?=htmlspecialchars($due)?></span>

--- a/completed.php
+++ b/completed.php
@@ -96,7 +96,7 @@ $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success
                 }
             ?>
             <div class="list-group-item d-flex align-items-start list-group-item-action" onclick="location.href='task.php?id=<?=$task['id']?>'" style="cursor: pointer;">
-                <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?></span>
+                <span class="flex-grow-1 text-break text-decoration-line-through"><?=htmlspecialchars($task['description'] ?? '')?></span>
                 <span class="d-flex align-items-center gap-2 ms-3 flex-shrink-0 text-nowrap">
                     <?php if ($due !== ''): ?>
                         <span class="small <?=$dueClass?>"><?=htmlspecialchars($due)?></span>

--- a/db.php
+++ b/db.php
@@ -1,10 +1,6 @@
 <?php
 session_start();
 
-function get_default_prefixes() {
-    return "T \nN \nX \nC \nM \n# \n## \n### ";
-}
-
 function get_db() {
     static $db = null;
     if ($db === null) {
@@ -16,8 +12,7 @@ function get_db() {
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
             location TEXT,
-            default_priority INTEGER NOT NULL DEFAULT 0,
-            special_prefixes TEXT
+            default_priority INTEGER NOT NULL DEFAULT 0
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -50,10 +45,6 @@ function get_db() {
         }
         if (!in_array('default_priority', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
-        }
-        if (!in_array('special_prefixes', $userColumns, true)) {
-            $db->exec('ALTER TABLE users ADD COLUMN special_prefixes TEXT');
-            $db->exec('UPDATE users SET special_prefixes = ' . $db->quote(get_default_prefixes()));
         }
     }
     return $db;

--- a/db.php
+++ b/db.php
@@ -1,6 +1,41 @@
 <?php
 session_start();
 
+const DEFAULT_PREFIXES = "T \nN \nX \nC \nM \n# \n## \n### ";
+
+function get_prefixes() {
+    if (!isset($_SESSION['special_prefixes']) || !is_array($_SESSION['special_prefixes'])) {
+        $_SESSION['special_prefixes'] = explode("\n", DEFAULT_PREFIXES);
+    }
+    return $_SESSION['special_prefixes'];
+}
+
+function format_description($text) {
+    $prefixes = get_prefixes();
+    $lines = preg_split("/\r\n|\r|\n/", $text);
+    foreach ($lines as &$line) {
+        $leadingLen = strspn($line, " \t");
+        $leading = substr($line, 0, $leadingLen);
+        $rest = substr($line, $leadingLen);
+        $prefix = '';
+        foreach ($prefixes as $p) {
+            if ($p !== '' && strpos($rest, $p) === 0) {
+                $prefix = $p;
+                $rest = substr($rest, strlen($p));
+                break;
+            }
+        }
+        $rest = preg_replace_callback('/^(\s*)(\S)/u', function($m){
+            $char = function_exists('mb_strtoupper')
+                ? mb_strtoupper($m[2], 'UTF-8')
+                : strtoupper($m[2]);
+            return $m[1] . $char;
+        }, $rest, 1);
+        $line = $leading . $prefix . $rest;
+    }
+    return implode("\n", $lines);
+}
+
 function get_db() {
     static $db = null;
     if ($db === null) {
@@ -12,7 +47,8 @@ function get_db() {
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
             location TEXT,
-            default_priority INTEGER NOT NULL DEFAULT 0
+            default_priority INTEGER NOT NULL DEFAULT 0,
+            special_prefixes TEXT
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -45,6 +81,9 @@ function get_db() {
         }
         if (!in_array('default_priority', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
+        }
+        if (!in_array('special_prefixes', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN special_prefixes TEXT');
         }
     }
     return $db;

--- a/db.php
+++ b/db.php
@@ -1,6 +1,10 @@
 <?php
 session_start();
 
+function get_default_prefixes() {
+    return "T \nN \nX \nC \nM \n# \n## \n### ";
+}
+
 function get_db() {
     static $db = null;
     if ($db === null) {
@@ -12,7 +16,8 @@ function get_db() {
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
             location TEXT,
-            default_priority INTEGER NOT NULL DEFAULT 0
+            default_priority INTEGER NOT NULL DEFAULT 0,
+            special_prefixes TEXT
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -45,6 +50,10 @@ function get_db() {
         }
         if (!in_array('default_priority', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
+        }
+        if (!in_array('special_prefixes', $userColumns, true)) {
+            $db->exec('ALTER TABLE users ADD COLUMN special_prefixes TEXT');
+            $db->exec('UPDATE users SET special_prefixes = ' . $db->quote(get_default_prefixes()));
         }
     }
     return $db;

--- a/index.php
+++ b/index.php
@@ -13,8 +13,6 @@ $stmt->execute([':uid' => $_SESSION['user_id']]);
 $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 $priority_labels = [0 => 'None', 1 => 'Low', 2 => 'Medium', 3 => 'High'];
 $priority_classes = [0 => 'bg-secondary-subtle text-secondary', 1 => 'bg-success-subtle text-success', 2 => 'bg-warning-subtle text-warning', 3 => 'bg-danger-subtle text-danger'];
-$special_prefixes = $_SESSION['special_prefixes'] ?? get_default_prefixes();
-$prefix_array = array_values(array_filter(array_map(fn($p) => rtrim($p, "\r"), explode("\n", $special_prefixes)), fn($p) => $p !== ''));
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -105,22 +103,6 @@ $prefix_array = array_values(array_filter(array_map(fn($p) => rtrim($p, "\r"), e
         <?php endforeach; ?>
     </div>
 </div>
-<script>
-const specialPrefixes = <?=json_encode($prefix_array)?>;
-(function(){
-  const input = document.querySelector('input[name="description"]');
-  if (!input) return;
-  input.addEventListener('input', function(){
-    const start = this.selectionStart;
-    let line = this.value;
-    const skip = specialPrefixes.some(p => line.startsWith(p)) || /^[\t ]/.test(line);
-    if (!skip) {
-      this.value = line.replace(/^([A-Za-z])/, c => c.toUpperCase());
-      this.selectionStart = this.selectionEnd = start;
-    }
-  });
-})();
-</script>
 <script src="sw-register.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/index.php
+++ b/index.php
@@ -102,7 +102,7 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
                 }
             ?>
             <a href="task.php?id=<?=$task['id']?>" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?></span>
+                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'] ?? '')?></span>
                 <span class="d-flex align-items-center gap-2">
                     <span class="small due-date text-end <?=$dueClass?>"><?=htmlspecialchars($due)?></span>
                     <span class="badge <?=$priority_classes[$p]?> priority-badge"><?=$priority_labels[$p]?></span>
@@ -114,5 +114,12 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
 </div>
 <script src="sw-register.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="capitalize.js"></script>
+<script>
+const prefixes = <?php echo json_encode(get_prefixes()); ?>;
+document.addEventListener('DOMContentLoaded', function(){
+    setupAutoCapitalize(document.querySelector('input[name="description"]'), prefixes);
+});
+</script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -102,7 +102,7 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
                 }
             ?>
             <a href="task.php?id=<?=$task['id']?>" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars($task['description'] ?? '')?></span>
+                <span class="<?php if ($task['done']) echo 'text-decoration-line-through'; ?>"><?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?></span>
                 <span class="d-flex align-items-center gap-2">
                     <span class="small due-date text-end <?=$dueClass?>"><?=htmlspecialchars($due)?></span>
                     <span class="badge <?=$priority_classes[$p]?> priority-badge"><?=$priority_labels[$p]?></span>

--- a/login.php
+++ b/login.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, special_prefixes FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -21,6 +21,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
             $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
+            $prefs = $user['special_prefixes'] ?? DEFAULT_PREFIXES;
+            $_SESSION['special_prefixes'] = array_filter(explode("\n", $prefs));
             header('Location: index.php');
             exit();
         } else {

--- a/login.php
+++ b/login.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, special_prefixes FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -21,6 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
             $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
+            $_SESSION['special_prefixes'] = $user['special_prefixes'] ?? get_default_prefixes();
             header('Location: index.php');
             exit();
         } else {

--- a/login.php
+++ b/login.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, special_prefixes FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -21,7 +21,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
             $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
-            $_SESSION['special_prefixes'] = $user['special_prefixes'] ?? get_default_prefixes();
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -15,12 +15,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, special_prefixes) VALUES (:username, :password, 0, :prefixes)');
-            $stmt->execute([
-                ':username' => $username,
-                ':password' => $hash,
-                ':prefixes' => get_default_prefixes()
-            ]);
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority) VALUES (:username, :password, 0)');
+            $stmt->execute([':username' => $username, ':password' => $hash]);
             header('Location: login.php');
             exit();
         } catch (PDOException $e) {

--- a/register.php
+++ b/register.php
@@ -15,8 +15,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority) VALUES (:username, :password, 0)');
-            $stmt->execute([':username' => $username, ':password' => $hash]);
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, special_prefixes) VALUES (:username, :password, 0, :prefixes)');
+            $stmt->execute([
+                ':username' => $username,
+                ':password' => $hash,
+                ':prefixes' => get_default_prefixes()
+            ]);
             header('Location: login.php');
             exit();
         } catch (PDOException $e) {

--- a/register.php
+++ b/register.php
@@ -15,8 +15,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority) VALUES (:username, :password, 0)');
-            $stmt->execute([':username' => $username, ':password' => $hash]);
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, special_prefixes) VALUES (:username, :password, 0, :pref)');
+            $stmt->execute([':username' => $username, ':password' => $hash, ':pref' => DEFAULT_PREFIXES]);
             header('Location: login.php');
             exit();
         } catch (PDOException $e) {

--- a/settings.php
+++ b/settings.php
@@ -12,6 +12,7 @@ $error = '';
 $username = $_SESSION['username'] ?? '';
 $location = $_SESSION['location'] ?? '';
 $default_priority = (int)($_SESSION['default_priority'] ?? 0);
+$special_prefixes = $_SESSION['special_prefixes'] ?? get_default_prefixes();
 $timezones = DateTimeZone::listIdentifiers();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -19,6 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = $_POST['password'] ?? '';
     $location = trim($_POST['location'] ?? '');
     $default_priority = (int)($_POST['default_priority'] ?? 0);
+    $special_prefixes = str_replace("\r", '', $_POST['special_prefixes'] ?? $special_prefixes);
     if ($default_priority < 0 || $default_priority > 3) {
         $default_priority = 0;
     }
@@ -29,26 +31,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             if ($password !== '') {
                 $hash = password_hash($password, PASSWORD_DEFAULT);
-                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri, special_prefixes = :sp WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':password' => $hash,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
+                    ':sp' => $special_prefixes,
                     ':id' => $_SESSION['user_id'],
                 ]);
             } else {
-                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri, special_prefixes = :sp WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
+                    ':sp' => $special_prefixes,
                     ':id' => $_SESSION['user_id'],
                 ]);
             }
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $location !== '' ? $location : 'UTC';
             $_SESSION['default_priority'] = $default_priority;
+            $_SESSION['special_prefixes'] = $special_prefixes;
             $message = 'Settings saved';
         } catch (PDOException $e) {
             $error = 'Username already taken';
@@ -123,6 +128,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <option value="1" <?php if ($default_priority == 1) echo 'selected'; ?>>Low</option>
                 <option value="0" <?php if ($default_priority == 0) echo 'selected'; ?>>None</option>
             </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="special_prefixes">Special Prefixes (one per line)</label>
+            <textarea name="special_prefixes" id="special_prefixes" class="form-control" rows="4"><?=htmlspecialchars($special_prefixes)?></textarea>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="index.php" class="btn btn-secondary">Back</a>

--- a/settings.php
+++ b/settings.php
@@ -12,7 +12,6 @@ $error = '';
 $username = $_SESSION['username'] ?? '';
 $location = $_SESSION['location'] ?? '';
 $default_priority = (int)($_SESSION['default_priority'] ?? 0);
-$special_prefixes = $_SESSION['special_prefixes'] ?? get_default_prefixes();
 $timezones = DateTimeZone::listIdentifiers();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -20,7 +19,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = $_POST['password'] ?? '';
     $location = trim($_POST['location'] ?? '');
     $default_priority = (int)($_POST['default_priority'] ?? 0);
-    $special_prefixes = str_replace("\r", '', $_POST['special_prefixes'] ?? $special_prefixes);
     if ($default_priority < 0 || $default_priority > 3) {
         $default_priority = 0;
     }
@@ -31,29 +29,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             if ($password !== '') {
                 $hash = password_hash($password, PASSWORD_DEFAULT);
-                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri, special_prefixes = :sp WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':password' => $hash,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
-                    ':sp' => $special_prefixes,
                     ':id' => $_SESSION['user_id'],
                 ]);
             } else {
-                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri, special_prefixes = :sp WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
-                    ':sp' => $special_prefixes,
                     ':id' => $_SESSION['user_id'],
                 ]);
             }
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $location !== '' ? $location : 'UTC';
             $_SESSION['default_priority'] = $default_priority;
-            $_SESSION['special_prefixes'] = $special_prefixes;
             $message = 'Settings saved';
         } catch (PDOException $e) {
             $error = 'Username already taken';
@@ -128,10 +123,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <option value="1" <?php if ($default_priority == 1) echo 'selected'; ?>>Low</option>
                 <option value="0" <?php if ($default_priority == 0) echo 'selected'; ?>>None</option>
             </select>
-        </div>
-        <div class="mb-3">
-            <label class="form-label" for="special_prefixes">Special Prefixes (one per line)</label>
-            <textarea name="special_prefixes" id="special_prefixes" class="form-control" rows="4"><?=htmlspecialchars($special_prefixes)?></textarea>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="index.php" class="btn btn-secondary">Back</a>

--- a/task.php
+++ b/task.php
@@ -17,9 +17,9 @@ if (!$task) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $description = ucwords(strtolower(trim($_POST['description'] ?? '')));
+    $description = format_description(trim($_POST['description'] ?? ''));
     $due_date = trim($_POST['due_date'] ?? '');
-    $details = trim($_POST['details'] ?? '');
+    $details = format_description(trim($_POST['details'] ?? ''));
     $priority = (int)($_POST['priority'] ?? 0);
     if ($priority < 0 || $priority > 3) {
         $priority = 0;
@@ -130,7 +130,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
     <form method="post">
         <div class="mb-3">
             <label class="form-label">Title</label>
-            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?>" required autocapitalize="none">
+            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars($task['description'] ?? '')?>" required autocapitalize="none">
         </div>
         <div class="mb-3 d-flex align-items-end gap-3">
             <div>
@@ -159,7 +159,9 @@ if ($p < 0 || $p > 3) { $p = 0; }
     </form>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="capitalize.js"></script>
 <script>
+const prefixes = <?php echo json_encode(get_prefixes()); ?>;
 (function(){
   const select = document.querySelector('select[name="priority"]');
   const badge = document.getElementById('priorityBadge');
@@ -237,7 +239,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
           scheduleSave();
         }
       });
-    }
+  }
 
   form.addEventListener('input', scheduleSave);
   form.addEventListener('change', scheduleSave);
@@ -247,6 +249,8 @@ if ($p < 0 || $p > 3) { $p = 0; }
       sendSave(true);
     }
   });
+    setupAutoCapitalize(document.querySelector('input[name="description"]'), prefixes);
+    setupAutoCapitalize(details, prefixes);
 })();
 </script>
 <script src="sw-register.js"></script>

--- a/task.php
+++ b/task.php
@@ -196,18 +196,6 @@ if ($p < 0 || $p > 3) { $p = 0; }
   }
 
   const specialPrefixes = <?=json_encode($prefix_array)?>;
-  const title = document.querySelector('input[name="description"]');
-  if (title) {
-    title.addEventListener('input', function(){
-      const start = this.selectionStart;
-      let line = this.value;
-      const skip = specialPrefixes.some(p => line.startsWith(p)) || /^[\t ]/.test(line);
-      if (!skip) {
-        this.value = line.replace(/^([A-Za-z])/, c => c.toUpperCase());
-        this.selectionStart = this.selectionEnd = start;
-      }
-    });
-  }
   const details = document.getElementById('detailsInput');
   if (details) {
     details.addEventListener('input', function(){

--- a/task.php
+++ b/task.php
@@ -16,11 +16,8 @@ if (!$task) {
     exit();
 }
 
-$special_prefixes = $_SESSION['special_prefixes'] ?? get_default_prefixes();
-$prefix_array = array_values(array_filter(array_map(fn($p) => rtrim($p, "\r"), explode("\n", $special_prefixes)), fn($p) => $p !== ''));
-
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $description = trim($_POST['description'] ?? '');
+    $description = ucwords(strtolower(trim($_POST['description'] ?? '')));
     $due_date = trim($_POST['due_date'] ?? '');
     $details = trim($_POST['details'] ?? '');
     $priority = (int)($_POST['priority'] ?? 0);
@@ -133,7 +130,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
     <form method="post">
         <div class="mb-3">
             <label class="form-label">Title</label>
-            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars($task['description'] ?? '')?>" required autocapitalize="none">
+            <input type="text" name="description" class="form-control" value="<?=htmlspecialchars(ucwords(strtolower($task['description'] ?? '')))?>" required autocapitalize="none">
         </div>
         <div class="mb-3 d-flex align-items-end gap-3">
             <div>
@@ -195,29 +192,13 @@ if ($p < 0 || $p > 3) { $p = 0; }
     }
   }
 
-  const specialPrefixes = <?=json_encode($prefix_array)?>;
   const details = document.getElementById('detailsInput');
   if (details) {
-    details.addEventListener('input', function(){
-      const start = this.selectionStart;
-      const end = this.selectionEnd;
-      const lines = this.value.split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        const skip = specialPrefixes.some(p => line.startsWith(p)) || /^[\t ]/.test(line);
-        if (!skip) {
-          lines[i] = line.replace(/^([A-Za-z])/, c => c.toUpperCase());
-        }
-      }
-      this.value = lines.join('\n');
-      this.selectionStart = start;
-      this.selectionEnd = end;
-    });
-    details.addEventListener('keydown', function(e) {
-      if (e.key === 'Tab') {
-        e.preventDefault();
-        const start = this.selectionStart;
-        const end = this.selectionEnd;
+      details.addEventListener('keydown', function(e) {
+        if (e.key === 'Tab') {
+          e.preventDefault();
+          const start = this.selectionStart;
+          const end = this.selectionEnd;
           this.value = this.value.slice(0, start) + "\t" + this.value.slice(end);
           this.selectionStart = this.selectionEnd = start + 1;
           scheduleSave();


### PR DESCRIPTION
## Summary
- allow users to configure special line prefixes in Settings and store them per account
- automatically capitalize the first word on each line while typing task titles or descriptions
- persist prefix-aware capitalization on the server when adding or editing tasks
- gracefully fall back to `strtoupper` when the `mbstring` extension is missing

## Testing
- `php -l db.php register.php login.php settings.php index.php task.php add_task.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4ab4224832692c718738af04e7c