### PR TITLE
Allow custom prefixes for description capitalization

### DIFF
--- a/db.php
+++ b/db.php
@@ -12,7 +12,8 @@ function get_db() {
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
             location TEXT,
-            default_priority INTEGER NOT NULL DEFAULT 0
+            default_priority INTEGER NOT NULL DEFAULT 0,
+            special_prefixes TEXT NOT NULL DEFAULT 'T \nN \nX \nC \nM \n# \n## \n### '
         )");
 
         $db->exec("CREATE TABLE IF NOT EXISTS tasks (
@@ -45,6 +46,9 @@ function get_db() {
         }
         if (!in_array('default_priority', $userColumns, true)) {
             $db->exec('ALTER TABLE users ADD COLUMN default_priority INTEGER NOT NULL DEFAULT 0');
+        }
+        if (!in_array('special_prefixes', $userColumns, true)) {
+            $db->exec("ALTER TABLE users ADD COLUMN special_prefixes TEXT NOT NULL DEFAULT 'T \nN \nX \nC \nM \n# \n## \n### '");
         }
     }
     return $db;

--- a/login.php
+++ b/login.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($username === '' || $password === '') {
         $error = 'Please fill in all fields';
     } else {
-        $stmt = get_db()->prepare('SELECT id, password, location, default_priority FROM users WHERE username = :username');
+        $stmt = get_db()->prepare('SELECT id, password, location, default_priority, special_prefixes FROM users WHERE username = :username');
         $stmt->execute([':username' => $username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
@@ -21,6 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $user['location'] ?? 'UTC';
             $_SESSION['default_priority'] = (int)($user['default_priority'] ?? 0);
+            $_SESSION['special_prefixes'] = $user['special_prefixes'] ?? "T \nN \nX \nC \nM \n# \n## \n### ";
             header('Location: index.php');
             exit();
         } else {

--- a/register.php
+++ b/register.php
@@ -15,8 +15,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         try {
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority) VALUES (:username, :password, 0)');
-            $stmt->execute([':username' => $username, ':password' => $hash]);
+            $defaultPrefixes = "T \nN \nX \nC \nM \n# \n## \n### ";
+            $stmt = get_db()->prepare('INSERT INTO users (username, password, default_priority, special_prefixes) VALUES (:username, :password, 0, :prefixes)');
+            $stmt->execute([':username' => $username, ':password' => $hash, ':prefixes' => $defaultPrefixes]);
             header('Location: login.php');
             exit();
         } catch (PDOException $e) {

--- a/settings.php
+++ b/settings.php
@@ -12,6 +12,12 @@ $error = '';
 $username = $_SESSION['username'] ?? '';
 $location = $_SESSION['location'] ?? '';
 $default_priority = (int)($_SESSION['default_priority'] ?? 0);
+$special_prefixes = $_SESSION['special_prefixes'] ?? '';
+if ($special_prefixes === '') {
+    $stmt = $db->prepare('SELECT special_prefixes FROM users WHERE id = :id');
+    $stmt->execute([':id' => $_SESSION['user_id']]);
+    $special_prefixes = $stmt->fetchColumn() ?: "T \nN \nX \nC \nM \n# \n## \n### ";
+}
 $timezones = DateTimeZone::listIdentifiers();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -19,6 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = $_POST['password'] ?? '';
     $location = trim($_POST['location'] ?? '');
     $default_priority = (int)($_POST['default_priority'] ?? 0);
+    $special_prefixes = str_replace("\r\n", "\n", $_POST['special_prefixes'] ?? $special_prefixes);
     if ($default_priority < 0 || $default_priority > 3) {
         $default_priority = 0;
     }
@@ -29,26 +36,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         try {
             if ($password !== '') {
                 $hash = password_hash($password, PASSWORD_DEFAULT);
-                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, password = :password, location = :loc, default_priority = :pri, special_prefixes = :sp WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':password' => $hash,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
+                    ':sp' => $special_prefixes,
                     ':id' => $_SESSION['user_id'],
                 ]);
             } else {
-                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri WHERE id = :id');
+                $stmt = $db->prepare('UPDATE users SET username = :username, location = :loc, default_priority = :pri, special_prefixes = :sp WHERE id = :id');
                 $stmt->execute([
                     ':username' => $username,
                     ':loc' => $location !== '' ? $location : null,
                     ':pri' => $default_priority,
+                    ':sp' => $special_prefixes,
                     ':id' => $_SESSION['user_id'],
                 ]);
             }
             $_SESSION['username'] = $username;
             $_SESSION['location'] = $location !== '' ? $location : 'UTC';
             $_SESSION['default_priority'] = $default_priority;
+            $_SESSION['special_prefixes'] = $special_prefixes;
             $message = 'Settings saved';
         } catch (PDOException $e) {
             $error = 'Username already taken';
@@ -123,6 +133,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <option value="1" <?php if ($default_priority == 1) echo 'selected'; ?>>Low</option>
                 <option value="0" <?php if ($default_priority == 0) echo 'selected'; ?>>None</option>
             </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="special_prefixes">Special Prefixes (one per line)</label>
+            <textarea name="special_prefixes" id="special_prefixes" class="form-control" rows="4"><?=htmlspecialchars($special_prefixes)?></textarea>
+            <div class="form-text">Prefixes to skip when capitalizing lines in task descriptions.</div>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
         <a href="index.php" class="btn btn-secondary">Back</a>

--- a/task.php
+++ b/task.php
@@ -48,6 +48,9 @@ $priority_classes = [
 ];
 $p = (int)($task['priority'] ?? 0);
 if ($p < 0 || $p > 3) { $p = 0; }
+$special_prefixes = $_SESSION['special_prefixes'] ?? "T \nN \nX \nC \nM \n# \n## \n### ";
+$prefixArray = array_values(array_filter(explode("\n", $special_prefixes), 'strlen'));
+usort($prefixArray, function($a, $b) { return strlen($b) - strlen($a); });
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -161,6 +164,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
 (function(){
+  const specialPrefixes = <?php echo json_encode($prefixArray); ?>;
   const select = document.querySelector('select[name="priority"]');
   const badge = document.getElementById('priorityBadge');
   if (select && badge) {
@@ -236,6 +240,33 @@ if ($p < 0 || $p > 3) { $p = 0; }
           }
           scheduleSave();
         }
+      });
+      details.addEventListener('input', function() {
+        const pos = this.selectionStart;
+        const lines = this.value.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          let line = lines[i];
+          const leading = line.match(/^[\t ]*/)[0];
+          let rest = line.slice(leading.length);
+          let prefix = '';
+          for (const p of specialPrefixes) {
+            if (rest.startsWith(p)) {
+              prefix = p;
+              rest = rest.slice(p.length);
+              break;
+            }
+          }
+          if (rest.length > 0) {
+            rest = rest.charAt(0).toUpperCase() + rest.slice(1);
+          }
+          lines[i] = leading + prefix + rest;
+        }
+        const newValue = lines.join('\n');
+        if (newValue !== this.value) {
+          this.value = newValue;
+          this.selectionStart = this.selectionEnd = pos;
+        }
+        scheduleSave();
       });
     }
 


### PR DESCRIPTION
## Summary
- Add `special_prefixes` user setting with defaults for T, N, X, C, M and Markdown headers
- Permit editing special prefixes via settings page
- Auto-capitalize first word per line in task description, skipping configured prefixes

## Testing
- `php -l db.php`
- `php -l register.php`
- `php -l login.php`
- `php -l settings.php`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5a9aef5b0832688cb18211affc80b