### PR TITLE
Refresh task list when returning to page

### DIFF
--- a/index.php
+++ b/index.php
@@ -114,5 +114,13 @@ $tomorrowFmt = $tomorrow->format('Y-m-d');
 </div>
 <script src="sw-register.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  window.addEventListener('pageshow', e => {
+    if (e.persisted) location.reload();
+  });
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) location.reload();
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure index page refreshes when restored from bfcache or becomes visible again

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c492bc64a8832693d7bee27acb65b9