### PR TITLE
Fix desktop newline handling in task editor

### DIFF
--- a/task.php
+++ b/task.php
@@ -232,7 +232,11 @@ if ($p < 0 || $p > 3) { $p = 0; }
             const lineStart = textBefore.lastIndexOf('\n') + 1;
             const currentLine = textBefore.slice(lineStart);
             const leading = currentLine.match(/^[\t ]*/)[0];
-            document.execCommand('insertText', false, "\n" + leading);
+            // insert newline using <br> to avoid collapsing when reading textContent
+            document.execCommand('insertHTML', false, '<br>');
+            if (leading) {
+              document.execCommand('insertText', false, leading);
+            }
             updateDetails();
             scheduleSave();
           }


### PR DESCRIPTION
## Summary
- Ensure pressing Enter in the task details editor inserts `<br>` elements so line breaks are preserved on desktop browsers
- Maintain indentation after the new line by inserting the existing leading whitespace

## Testing
- `php -l task.php`

------
https://chatgpt.com/codex/tasks/task_e_68c49147f5c08326915db34850ba68cd