### PR TITLE
Fix desktop newline handling in task editor

### DIFF
--- a/task.php
+++ b/task.php
@@ -232,7 +232,17 @@ if ($p < 0 || $p > 3) { $p = 0; }
             const lineStart = textBefore.lastIndexOf('\n') + 1;
             const currentLine = textBefore.slice(lineStart);
             const leading = currentLine.match(/^[\t ]*/)[0];
-            document.execCommand('insertText', false, "\n" + leading);
+            const br = document.createElement('br');
+            const textNode = document.createTextNode(leading);
+            range.deleteContents();
+            range.insertNode(br);
+            range.setStartAfter(br);
+            range.collapse(true);
+            range.insertNode(textNode);
+            range.setStart(textNode, textNode.length);
+            range.collapse(true);
+            sel.removeAllRanges();
+            sel.addRange(range);
             updateDetails();
             scheduleSave();
           }

--- a/task.php
+++ b/task.php
@@ -187,7 +187,7 @@ if ($p < 0 || $p > 3) { $p = 0; }
   const detailsField = document.getElementById('detailsField');
   if (details && detailsField) {
       updateDetails = function() {
-        detailsField.value = details.textContent;
+        detailsField.value = details.innerText;
       };
       details.addEventListener('input', function(){
         updateDetails();


### PR DESCRIPTION
## Summary
- Ensure pressing Enter inserts a newline and keeps the caret ready for typing
- Use DOM range operations instead of `execCommand` to maintain indentation and allow new lines

## Testing
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_68c49147f5c08326915db34850ba68cd